### PR TITLE
Fix Jupyter logging (at least in Windows?)

### DIFF
--- a/src/auspex/log.py
+++ b/src/auspex/log.py
@@ -7,7 +7,22 @@
 #    http://www.apache.org/licenses/LICENSE-2.0
 
 import logging
+import sys
+import importlib
+
+def in_jupyter():
+    try:
+        __IPYTHON__
+        return True
+    except NameError:
+        return False
 
 logger = logging.getLogger('auspex')
 logging.basicConfig(format='%(name)s-%(levelname)s: %(asctime)s ----> %(message)s')
 logger.setLevel(logging.INFO)
+
+if in_jupyter():
+    importlib.reload(logging)
+    logger.handlers = [logging.StreamHandler(sys.stderr)]
+    formatter = logging.Formatter('%(name)s-%(levelname)s: %(asctime)s ----> %(message)s')
+    logger.handlers[0].setFormatter(formatter)


### PR DESCRIPTION
Logging in Jupyter on Windows using `Jupyter 4.2.1` / `IPython 5.1.0` / `Python 3.5.2` only displays log messages in the terminal window and strips format. 
I haven't actually figured out *why* this is happening, but this PR restores log message format and displays them in the "red box" underneath a Jupyter cell. I haven't actually 