### PR TITLE
Set arbitrary kernel

### DIFF
--- a/src/auspex/filters/integrator.py
+++ b/src/auspex/filters/integrator.py
@@ -53,7 +53,7 @@ class KernelIntegrator(Filter):
             # add modulation
             kernel *= np.exp(2j * np.pi * self.frequency.value * time_step * time_pts)
         else:
-            kernel = eval(self.kernel.value.encode('unicode_escape'))
+            kernel = self.kernel.value
         # pad or truncate the kernel to match the record length
         if kernel.size < record_length:
             self.aligned_kernel = np.append(kernel, np.zeros(record_length-kernel.size, dtype=np.complex128))


### PR DESCRIPTION
Isn't the kernel already a numpy.array at this point? The string should already be evaluated [here](https://github.com/BBN-Q/Auspex/blob/51c09a5dfac0d17a09414339ad5b16a46be69eb0/src/auspex/exp_factory.py#L384).