### PR TITLE
Enable plotters independently of writers

### DIFF
--- a/src/auspex/exp_factory.py
+++ b/src/auspex/exp_factory.py
@@ -104,12 +104,23 @@ class QubitExpFactory(object):
                     raise Exception("No viable data writer was found for receiver channel {}. Please enabled only one!".format(receiver_text))
                 
                 # Trace back our ancestors
-                ancestors = nx.ancestors(dag, writers[0])
+                writer_ancestors = nx.ancestors(dag, writers[0])
                 # We will have gotten the digitizer, which should be removed since we're already taking care of it
-                ancestors.remove(dig_name)
-                filt_to_enable.extend(ancestors)
+                writer_ancestors.remove(dig_name)
 
-            # Disable digitizers and APSs and then build ourselved back up with the relevant nodes
+                instrument_settings['instrDict'][dig_name]['nbr_segments'] = num_segments
+
+                plotters = [e for e in endpoints if measurement_settings["filterDict"][e]["x__class__"] == "Plotter" and
+                                                   measurement_settings["filterDict"][e]["enabled"]]
+                if plotters:
+                    plotter_ancestors = set().union(*[nx.ancestors(dag, pl) for pl in plotters])
+                    plotter_ancestors.remove(dig_name)
+                else:
+                    plotter_ancestors = []
+
+                filt_to_enable.extend(set().union(writers, writer_ancestors, plotters, plotter_ancestors))
+
+            # Disable digitizers and APSs and then build ourself back up with the relevant nodes
             for instr_name in instrument_settings['instrDict'].keys():
                 if instrument_settings['instrDict'][instr_name]["x__module__"] in ['instruments.Digitizers', 'instruments.APS', 'instruments.APS2']:
                     instrument_settings['instrDict'][instr_name]['enabled'] = False


### PR DESCRIPTION
Allow plots (and ancestors) even if there is no associated writer