### PR TITLE
Turn Bokeh server into a persistent process (daemon)

### DIFF
--- a/src/auspex/filters/plot.py
+++ b/src/auspex/filters/plot.py
@@ -134,29 +134,23 @@ class Plotter(Filter):
             self.plot_buffer[self.idx:self.idx+data.size] = data.flatten()
             self.idx += data.size
 
-        if self.plot_dims.value == 1:
-            if (time.time() - self.last_update >= self.update_interval):
-                for i,j in zip(self.mapping_functions, self.data_sources):
-                    for mapping_function, data_source in zip(i,j):
+        if (time.time() - self.last_update >= self.update_interval):
+            for i,j in zip(self.mapping_functions, self.data_sources):
+                for mapping_function, data_source in zip(i,j):
+                    if self.plot_dims.value == 1:
                         data_source.data["y"] = np.copy(mapping_function(self.plot_buffer))
-                self.last_update = time.time()
-
-        else:
-            if (time.time() - self.last_update >= self.update_interval):
-                for i,j in zip(self.mapping_functions, self.data_sources):
-                    for mapping_function, data_source in zip(i,j):
+                    else:
                         data_source.data["image"] = [np.reshape(mapping_function(self.plot_buffer), self.z_data.shape)]
-                self.last_update = time.time()
+            self.last_update = time.time()
 
     async def on_done(self):
-        if self.plot_dims.value == 1:
-            for i,j in zip(self.mapping_functions, self.data_sources):
-                for mapping_function, data_source in zip(i,j):
+        for i,j in zip(self.mapping_functions, self.data_sources):
+            for mapping_function, data_source in zip(i,j):
+                if self.plot_dims.value == 1:
                     data_source.data["y"] = np.copy(mapping_function(self.plot_buffer))
-        else:
-            for i,j in zip(self.mapping_functions, self.data_sources):
-                for mapping_function, data_source in zip(i,j):
+                else:
                     data_source.data["image"] = [np.reshape(mapping_function(self.plot_buffer), self.z_data.shape)]
+
         time.sleep(0.1)
 
     def axis_label(self, index):
@@ -294,7 +288,7 @@ class XYPlotter(Filter):
         self.plot = self.fig.multi_line(x_data, y_data, name=self.name,
                                         line_width=2, color=self.colors,
                                         **self.plot_args)
-        
+
         renderers = self.plot.select(dict(name=self.name))
         self.renderer = [r for r in renderers if isinstance(r, GlyphRenderer)][0]
         self.data_source = self.renderer.data_source
@@ -318,7 +312,7 @@ class XYPlotter(Filter):
                     raise ValueError("Writer received concurrent messages with different message types {}".format([m['type'] for m in messages]))
             except:
                 import ipdb; ipdb.set_trace()
-                
+
             # Infer the type from the first message
             message_type = messages[0]['type']
 
@@ -380,7 +374,7 @@ class XYPlotter(Filter):
                     # Strip NaNs
                     x_data = np.array([series[~np.isnan(series)] for series in x_data])
                     y_data = np.array([series[~np.isnan(series)] for series in y_data])
-                    
+
                     # Convert to lists and then push all at once...
                     self.data_source.data = dict(xs=x_data.tolist(), ys=y_data.tolist(), line_color=self.colors[0:len(y_data)])
 
@@ -391,4 +385,3 @@ class XYPlotter(Filter):
     #         for mapping_function, data_source in zip(i,j):
     #             data_source.data["y"] = np.copy(mapping_function(self.plot_buffer))
     #     time.sleep(0.1)
-

--- a/src/auspex/plotting.py
+++ b/src/auspex/plotting.py
@@ -11,33 +11,59 @@ import subprocess
 import psutil
 import os
 import sys
+import tempfile
+import time
 
 from auspex.log import logger
 
-class BokehServerThread(threading.Thread):
+class BokehServerProcess(object):
     def __init__(self, notebook=False):
-        super(BokehServerThread, self).__init__()
-        self.daemon = True
+        super(BokehServerProcess, self).__init__()
         self.run_in_notebook = notebook
-
-    def __del__(self):
-        self.join()
+        self.pid_filename = os.path.join(tempfile.gettempdir(), "auspex_bokeh.pid")
 
     def run(self):
+        # start a Bokeh server if one is not already running
+        pid = self.read_session_pid()
+        if pid:
+            self.p = psutil.Process(pid)
+            logger.info("Using existing Bokeh server")
+            return
+        logger.info("Starting Bokeh server")
         args = ["bokeh", "serve", "--port", "5006"]
         if self.run_in_notebook:
             args.append("--allow-websocket-origin=localhost:8888")
         self.p = subprocess.Popen(args, env=os.environ.copy())
+        self.write_session_pid()
+        # sleep to give the Bokeh server a chance to start
+        # TODO replace this with some bokeh client API call that
+        # verifies that the server is running
+        time.sleep(3)
 
-    def join(self, timeout=None):
+    def terminate(self):
         if self.p:
-            print("Killing bokeh server thread {}".format(self.p.pid))
+            print("Killing bokeh server process {}".format(self.p.pid))
             try:
                 for child_proc in psutil.Process(self.p.pid).children():
                     print("Killing child process {}".format(child_proc.pid))
-                    child_proc.kill()
+                    child_proc.terminate()
             except:
                 print("Couldn't kill child processes.")
-            self.p.kill()
+            self.p.terminate()
             self.p = None
-            super(BokehServerThread, self).join(timeout=timeout)
+            os.remove(self.pid_filename)
+
+    def write_session_pid(self):
+        with open(self.pid_filename, "w") as f:
+            f.write("{}\n".format(self.p.pid))
+
+    def read_session_pid(self):
+        # check if pid file exists
+        if not os.path.isfile(self.pid_filename):
+            return None
+        with open(self.pid_filename) as f:
+            pid = int(f.readline())
+        if psutil.pid_exists(pid):
+            return pid
+        else:
+            return None


### PR DESCRIPTION
Writes the Bokeh server PID to file upon loading the server. When launching a
new experiment, we check for the existence of a running process on that PID, and
skip loading the Bokeh server if we find it.

An open issue is to figure out how/when to shut the Bokeh server down. Ideally,
it would timeout if it hadn't received any messages after XX seconds. Not sure
how to make that happen, though.

Also, this code does not "double fork" the Bokeh process. Consequently, if the
user sends SIGINT with Ctrl-C, that will shut down the Bokeh server. Not sure if
you want to think of that as a feature or a bug.