### PR TITLE
Fix/adaptive tuples

### DIFF
--- a/src/auspex/analysis/io.py
+++ b/src/auspex/analysis/io.py
@@ -27,7 +27,10 @@ def load_from_HDF5(filename_or_fileobject, return_structured_array=True):
             ax = g[ref]
             if ax.attrs['unstructured']:
                 # The entry for the main unstructured axis contains
-                # references to the constituent axes
+                # references to the constituent axes.
+                
+                # The DataAxis expects points as tuples coordinates 
+                # in the form [(x1, y1), (x2, y2), ...].
                 points = np.vstack([g[e] for e in ax[:]]).T
                 names = [g[e].attrs["name"] for e in ax[:]]
                 units = [g[e].attrs["unit"] for e in ax[:]]

--- a/src/auspex/analysis/io.py
+++ b/src/auspex/analysis/io.py
@@ -12,7 +12,52 @@ from auspex.log import logger
 import h5py
 import numpy as np
 
-def load_from_HDF5(filename_or_fileobject):
+def load_from_HDF5(filename_or_fileobject, return_structured_array=True):
+    data = {}
+    if isinstance(filename_or_fileobject, h5py.File):
+        f = filename_or_fileobject
+    else:
+        f = h5py.File(filename_or_fileobject, 'r')
+    for groupname in f:
+        # Reconstruct the descrciptor
+        descriptor = DataStreamDescriptor()
+        g = f[groupname]
+        axis_refs = g['descriptor']
+        for ref in reversed(axis_refs):
+            ax = g[ref]
+            if ax.attrs['unstructured']:
+                # The entry for the main unstructured axis contains
+                # references to the constituent axes
+                points = np.vstack([g[e] for e in ax[:]]).T
+                names = [g[e].attrs["name"] for e in ax[:]]
+                units = [g[e].attrs["unit"] for e in ax[:]]
+                descriptor.add_axis(DataAxis(names, points=points, unit=units))
+            else:
+                name = ax.attrs['name']
+                unit = ax.attrs['unit']
+                points = ax[:]
+                descriptor.add_axis(DataAxis(name, points=points, unit=unit))
+
+        for attr_name in axis_refs.attrs.keys():
+            descriptor.metadata[attr_name] = axis_refs.attrs[attr_name]
+
+        col_names = list(g['data'].keys())
+        if return_structured_array:
+            dtype = [(g['data'][n].attrs['name'], g['data'][n].dtype.char) for n in col_names]
+            length = g['data'][col_names[0]].shape[0]
+            group_data = np.empty((length,), dtype=dtype) 
+            for cn in col_names:
+                group_data[cn] = g['data'][cn]
+        else:
+            group_data = {n: g['data'][n][:] for n in col_names}
+        
+
+        data[groupname] = group_data
+
+    f.close()
+    return data, descriptor
+
+def load_from_HDF5_legacy(filename_or_fileobject):
     data = {}
     if isinstance(filename_or_fileobject, h5py.File):
         f = filename_or_fileobject

--- a/src/auspex/experiment.py
+++ b/src/auspex/experiment.py
@@ -310,12 +310,13 @@ class Experiment(metaclass=MetaExperiment):
         while True:
             # Increment the sweeper and get the current set of values
             sweep_values = await self.sweeper.update()
-            
             # Add the new tuples to the stream descriptors
             for oc in self.output_connectors.values():
                 vals = [a for a in oc.descriptor.data_axis_values()] # Make sure they are lists
                 if sweep_values:
-                    vals  = [[(v,)] for v in sweep_values] + vals
+                    vals  = [[v] for v in sweep_values] + vals
+
+                # vals = sweep_values + vals
                 nested_list    = list(itertools.product(*vals))
                 flattened_list = [tuple((val for sublist in line for val in sublist)) for line in nested_list]
                 oc.descriptor.visited_tuples = oc.descriptor.visited_tuples + flattened_list

--- a/src/auspex/experiment.py
+++ b/src/auspex/experiment.py
@@ -310,17 +310,22 @@ class Experiment(metaclass=MetaExperiment):
 
         done = True
         while True:
-            # Increment the sweeper and get the current set of values
+            # Increment the sweeper, which returns a list of the current
+            # values of the SweepAxes (no DataAxes).
             sweep_values = await self.sweeper.update()
 
             if self.sweeper.is_adaptive():
                 # Add the new tuples to the stream descriptors
                 for oc in self.output_connectors.values():
-                    vals = [a for a in oc.descriptor.data_axis_values()] # Make sure they are lists
+                    # Obtain the lists of values for any fixed
+                    # DataAxes and append them to them to the sweep_values
+                    # in preperation for finding all combinations. 
+                    vals = [a for a in oc.descriptor.data_axis_values()]
                     if sweep_values:
                         vals  = [[v] for v in sweep_values] + vals
 
-                    # vals = sweep_values + vals
+                    # Find all coordinate tuples and update the list of 
+                    # tuples that the experiment has probed.
                     nested_list    = list(itertools.product(*vals))
                     flattened_list = [tuple((val for sublist in line for val in sublist)) for line in nested_list]
                     oc.descriptor.visited_tuples = oc.descriptor.visited_tuples + flattened_list

--- a/src/auspex/experiment.py
+++ b/src/auspex/experiment.py
@@ -328,7 +328,10 @@ class Experiment(metaclass=MetaExperiment):
             await self.run()
 
             # See if the axes want to extend themselves
-            await self.sweeper.check_for_refinement()
+            refined_axes = await self.sweeper.check_for_refinement()
+            for oc in self.output_connectors.values():
+                if len(refined_axes) > 0:
+                     await oc.push_event("refined", refined_axes)
 
             # Update progress bars
             if self.progressbar is not None:

--- a/src/auspex/filters/average.py
+++ b/src/auspex/filters/average.py
@@ -7,12 +7,45 @@
 #    http://www.apache.org/licenses/LICENSE-2.0
 
 import time
+import itertools
 import numpy as np
 
 from .filter import Filter
 from auspex.log import logger
 from auspex.parameter import Parameter
 from auspex.stream import InputConnector, OutputConnector
+
+def view_fields(a, names):
+    """
+    `a` must be a numpy structured array.
+    `names` is the collection of field names to keep.
+
+    Returns a view of the array `a` (not a copy).
+    http://stackoverflow.com/questions/37079175/how-to-remove-a-column-from-a-structured-numpy-array-without-copying-it
+    """
+    dt = a.dtype
+    formats = [dt.fields[name][0] for name in names]
+    offsets = [dt.fields[name][1] for name in names]
+    itemsize = a.dtype.itemsize
+    newdt = np.dtype(dict(names=names,
+                          formats=formats,
+                          offsets=offsets,
+                          itemsize=itemsize))
+    b = a.view(newdt)
+    return b
+
+def remove_fields(a, names):
+    """
+    `a` must be a numpy structured array.
+    `names` is the collection of field names to remove.
+
+    Returns a view of the array `a` (not a copy).
+    http://stackoverflow.com/questions/37079175/how-to-remove-a-column-from-a-structured-numpy-array-without-copying-it
+    """
+    dt = a.dtype
+    keep_names = [name for name in dt.names if name not in names]
+    return view_fields(a, keep_names)
+
 
 class Averager(Filter):
     """Takes data and collapses along the specified axis."""
@@ -50,9 +83,7 @@ class Averager(Filter):
         # Convert named axes to an index
         if self.axis.value not in names:
             raise ValueError("Could not find axis {} within the DataStreamDescriptor {}".format(self.axis.value, descriptor_in))
-        self.axis_num = names.index(self.axis.value)
-        logger.debug("Axis %s corresponds to numerical axis %d", self.axis.value, self.axis_num)
-
+        self.axis_num = descriptor_in.axis_num(self.axis.value)
         logger.debug("Averaging over axis #%d: %s", self.axis_num, self.axis.value)
 
         self.data_dims = descriptor_in.data_dims()
@@ -86,21 +117,37 @@ class Averager(Filter):
         self.partial_average.descriptor = descriptor
         self.final_average.descriptor   = descriptor
 
+        # We can update the visited_tuples upfront if none 
+        # of the sweeps are adaptive...
+        desc_out_dtype = descriptor_in.axis_data_type(with_metadata=True, excluding_axis=self.axis.value)
+        if not descriptor_in.is_adaptive():
+            vals           = [a.points_with_metadata() for a in descriptor_in.axes if a.name != self.axis.value]
+            nested_list    = list(itertools.product(*vals))
+            flattened_list = [tuple((val for sublist in line for val in sublist)) for line in nested_list]
+            descriptor.visited_tuples = np.core.records.fromrecords(flattened_list, dtype=desc_out_dtype)
+        else:
+            descriptor.visited_tuples = np.empty(dtype=desc_out_dtype)
+
         for stream in self.partial_average.output_streams + self.final_average.output_streams:
             stream.set_descriptor(descriptor)
             stream.end_connector.update_descriptors()
 
         # Define variance axis descriptor
-        descriptor = descriptor_in.copy()
-        descriptor.data_name = "Variance"
-        descriptor.pop_axis(self.axis.value)
-        if descriptor.unit:
-            descriptor.unit = descriptor.unit + "^2"
-        descriptor.metadata["num_averages"] = self.num_averages
-        self.final_variance.descriptor = descriptor
+        descriptor_var = descriptor_in.copy()
+        descriptor_var.data_name = "Variance"
+        descriptor_var.pop_axis(self.axis.value)
+        if descriptor_var.unit:
+            descriptor_var.unit = descriptor_var.unit + "^2"
+        descriptor_var.metadata["num_averages"] = self.num_averages
+        self.final_variance.descriptor= descriptor_var
+
+        if not descriptor_in.is_adaptive():
+            descriptor_var.visited_tuples = np.core.records.fromrecords(flattened_list, dtype=desc_out_dtype)
+        else:
+            descriptor_var.visited_tuples = np.empty(dtype=desc_out_dtype)
 
         for stream in self.final_variance.output_streams:
-            stream.set_descriptor(descriptor)
+            stream.set_descriptor(descriptor_var)
             stream.end_connector.update_descriptors()
 
     def final_init(self):
@@ -109,6 +156,7 @@ class Averager(Filter):
 
         self.completed_averages = 0
         self.idx_frame          = 0
+        self.idx_global         = 0
         # We only need to accumulate up to the averaging axis
         # BUT we may get something longer at any given time!
         self.carry = np.zeros(0, dtype=self.final_average.descriptor.dtype)
@@ -136,6 +184,18 @@ class Averager(Filter):
                 reshaped   = data[idx:idx+new_points].reshape(self.reshape_dims)
                 averaged   = reshaped.mean(axis=self.mean_axis)
                 idx       += new_points
+
+                if self.sink.descriptor.is_adaptive():
+                    import ipdb; ipdb.set_trace()
+                    new_tuples = self.sink.descriptor.tuples()[self.idx_global:self.idx_global + len(reshaped)]
+                    new_tuples_stripped = remove_fields(new_tuples, self.axis.value)
+                    take_axis = -1 if self.axis_num > 0 else 0 
+                    reduced_tuples = new_tuples_stripped.reshape(self.reshape_dims).take((0,), axis=take_axis)
+
+                # Add to Visited tuples
+                if self.sink.descriptor.is_adaptive():
+                    for os in self.final_average.output_streams + self.final_variance.output_streams + self.partial_average.output_streams:
+                        os.descriptor.visited_tuples = np.append(os.descriptor.visited_tuples, reduced_tuples)
 
                 for os in self.final_average.output_streams:
                     await os.push(averaged)

--- a/src/auspex/filters/average.py
+++ b/src/auspex/filters/average.py
@@ -186,7 +186,6 @@ class Averager(Filter):
                 idx       += new_points
 
                 if self.sink.descriptor.is_adaptive():
-                    import ipdb; ipdb.set_trace()
                     new_tuples = self.sink.descriptor.tuples()[self.idx_global:self.idx_global + len(reshaped)]
                     new_tuples_stripped = remove_fields(new_tuples, self.axis.value)
                     take_axis = -1 if self.axis_num > 0 else 0 

--- a/src/auspex/filters/correlator.py
+++ b/src/auspex/filters/correlator.py
@@ -19,17 +19,8 @@ class Correlator(ElementwiseFilter):
     def operation(self):
         return np.multiply
 
-    def update_descriptors(self):
-        logger.debug('Updating correlator "%s" descriptors based on input descriptor: %s.', self.name, self.sink.descriptor)
+    def filter_name(self):
+        return "Correlator"
 
-        # Sometimes not all of the input descriptors have been updated... pause here until they are:
-        if None in [ss.descriptor for ss in self.sink.input_streams]:
-            logger.debug('Correlator "%s" waiting for all input streams to be updated.', self.name)
-            return
-
-        descriptor = self.sink.descriptor.copy()
-        descriptor.data_name = "Correlator"
-        if descriptor.unit:
-            descriptor.unit = descriptor.unit + "^{}".format(len(self.sink.input_streams))
-        self.source.descriptor = descriptor
-        self.source.update_descriptors()
+    def unit(self, base_unit):
+        return base_unit + "^{}".format(len(self.sink.input_streams))

--- a/src/auspex/filters/correlator.py
+++ b/src/auspex/filters/correlator.py
@@ -13,14 +13,12 @@ from auspex.log import logger
 from .elementwise import ElementwiseFilter
 
 class Correlator(ElementwiseFilter):
-    sink   = InputConnector()
-    source = OutputConnector()
+    sink        = InputConnector()
+    source      = OutputConnector()
+    filter_name = "Correlator"
 
     def operation(self):
         return np.multiply
-
-    def filter_name(self):
-        return "Correlator"
 
     def unit(self, base_unit):
         return base_unit + "^{}".format(len(self.sink.input_streams))

--- a/src/auspex/filters/elementwise.py
+++ b/src/auspex/filters/elementwise.py
@@ -82,7 +82,7 @@ class ElementwiseFilter(Filter):
                 message_comp = message['compression']
                 message_data = pickle.loads(zlib.decompress(message_data)) if message_comp == 'zlib' else message_data
                 message_data = message_data if hasattr(message_data, 'size') else np.array([message_data])
-                if message_type == 'event' and message_data == 'done':
+                if message_type == 'event' and message['event_type'] == 'done':
                     stream_done[stream] = True
 
                 elif message_type == 'data':

--- a/src/auspex/filters/elementwise.py
+++ b/src/auspex/filters/elementwise.py
@@ -25,8 +25,9 @@ class ElementwiseFilter(Filter):
     """Asynchronously perform elementwise operations on multiple streams:
     e.g. multiply or add all streams element-by-element"""
 
-    sink   = InputConnector()
-    source = OutputConnector()
+    sink        = InputConnector()
+    source      = OutputConnector()
+    filter_name = "GenericElementwise" # To identify subclasses when naming data streams
 
     def __init__(self, **kwargs):
         super(ElementwiseFilter, self).__init__(**kwargs)
@@ -37,11 +38,6 @@ class ElementwiseFilter(Filter):
         """Must be overridden with the desired mathematical function"""
         pass
 
-    def filter_name(self):
-        """Give the name of the subclass, e.g.
-        return "Correlator" """
-        pass
-
     def unit(self, base_unit):
         """Must be overridden accoriding the desired mathematical function
         e.g. return base_unit + "^{}".format(len(self.sink.input_streams))"""
@@ -49,15 +45,15 @@ class ElementwiseFilter(Filter):
 
     def update_descriptors(self):
         """Must be overridden depending on the desired mathematical function"""
-        logger.debug('Updating %s "%s" descriptors based on input descriptor: %s.', self.filter_name(), self.name, self.sink.descriptor)
+        logger.debug('Updating %s "%s" descriptors based on input descriptor: %s.', self.filter_name, self.name, self.sink.descriptor)
 
         # Sometimes not all of the input descriptors have been updated... pause here until they are:
         if None in [ss.descriptor for ss in self.sink.input_streams]:
-            logger.debug('%s "%s" waiting for all input streams to be updated.', self.filter_name(), self.name)
+            logger.debug('%s "%s" waiting for all input streams to be updated.', self.filter_name, self.name)
             return
 
         self.descriptor = self.sink.descriptor.copy()
-        self.descriptor.data_name = self.filter_name()
+        self.descriptor.data_name = self.filter_name
         if self.descriptor.unit:
             self.descriptor.unit = self.descriptor.unit + "^{}".format(len(self.sink.input_streams))
         self.source.descriptor = self.descriptor

--- a/src/auspex/filters/elementwise.py
+++ b/src/auspex/filters/elementwise.py
@@ -37,15 +37,37 @@ class ElementwiseFilter(Filter):
         """Must be overridden with the desired mathematical function"""
         pass
 
+    def filter_name(self):
+        """Give the name of the subclass, e.g.
+        return "Correlator" """
+        pass
+
+    def unit(self, base_unit):
+        """Must be overridden accoriding the desired mathematical function
+        e.g. return base_unit + "^{}".format(len(self.sink.input_streams))"""
+        pass
+
     def update_descriptors(self):
         """Must be overridden depending on the desired mathematical function"""
-        pass
+        logger.debug('Updating %s "%s" descriptors based on input descriptor: %s.', self.filter_name(), self.name, self.sink.descriptor)
+
+        # Sometimes not all of the input descriptors have been updated... pause here until they are:
+        if None in [ss.descriptor for ss in self.sink.input_streams]:
+            logger.debug('%s "%s" waiting for all input streams to be updated.', self.filter_name(), self.name)
+            return
+
+        self.descriptor = self.sink.descriptor.copy()
+        self.descriptor.data_name = self.filter_name()
+        if self.descriptor.unit:
+            self.descriptor.unit = self.descriptor.unit + "^{}".format(len(self.sink.input_streams))
+        self.source.descriptor = self.descriptor
+        self.source.update_descriptors()
 
     async def run(self):
         streams = self.sink.input_streams
 
         for s in streams[1:]:
-            if not np.all(s.descriptor.tuples() == streams[0].descriptor.tuples()):
+            if not np.all(s.descriptor.expected_tuples() == streams[0].descriptor.expected_tuples()):
                 raise ValueError("Multiple streams connected to correlator must have matching descriptors.")
 
         # Buffers for stream data
@@ -82,8 +104,11 @@ class ElementwiseFilter(Filter):
                 message_comp = message['compression']
                 message_data = pickle.loads(zlib.decompress(message_data)) if message_comp == 'zlib' else message_data
                 message_data = message_data if hasattr(message_data, 'size') else np.array([message_data])
-                if message_type == 'event' and message['event_type'] == 'done':
-                    stream_done[stream] = True
+                if message_type == 'event':
+                    if message['event_type'] == 'done':
+                        stream_done[stream] = True
+                    elif message['event_type'] == 'refine':
+                        logger.warning("Correlator doesn't handle refinement yet!")
 
                 elif message_type == 'data':
                     stream_data[stream] = np.concatenate((stream_data[stream], message_data.flatten()))

--- a/src/auspex/filters/filter.py
+++ b/src/auspex/filters/filter.py
@@ -124,9 +124,12 @@ class Filter(metaclass=MetaFilter):
                         await os.queue.put(message)
 
                 # Check to see if we're done
-                if message['data'] == 'done':
+                if message['event_type'] == 'done':
                     await self.on_done()
                     break
+                elif message['event_type'] == 'refined':
+                    print("Filter got refine", message_data)
+                    await self.refine(message_data)
 
             elif message['type'] == 'data':
                 if not hasattr(message_data, 'size'):
@@ -144,4 +147,8 @@ class Filter(metaclass=MetaFilter):
 
     async def process_direct(self, data):
         """Process direct data, ignore things like the data descriptors."""
+        pass
+
+    async def refine(self, axes):
+        """Try to deal with a refinement along the given axes."""
         pass

--- a/src/auspex/filters/filter.py
+++ b/src/auspex/filters/filter.py
@@ -149,6 +149,6 @@ class Filter(metaclass=MetaFilter):
         """Process direct data, ignore things like the data descriptors."""
         pass
 
-    async def refine(self, axes):
+    async def refine(self, axis):
         """Try to deal with a refinement along the given axes."""
         pass

--- a/src/auspex/filters/filter.py
+++ b/src/auspex/filters/filter.py
@@ -128,7 +128,6 @@ class Filter(metaclass=MetaFilter):
                     await self.on_done()
                     break
                 elif message['event_type'] == 'refined':
-                    print("Filter got refine", message_data)
                     await self.refine(message_data)
 
             elif message['type'] == 'data':

--- a/src/auspex/filters/io.py
+++ b/src/auspex/filters/io.py
@@ -115,7 +115,7 @@ class WriteToHDF5(Filter):
         num_axes   = len(axes)
 
         # All of the combinations for the present values of the sweep parameters only
-        # tuples          = desc.expected_tuples(with_metadata=True, as_structured_array=True)
+        tuples          = desc.expected_tuples(with_metadata=True, as_structured_array=True)
         expected_length = desc.expected_num_points()
 
         # If desired, create the group in which the dataset and axes will reside
@@ -181,6 +181,11 @@ class WriteToHDF5(Filter):
             self.data.dims.create_scale(self.group[name], name)
             self.data.dims[0].attach_scale(self.group[name])
             self.descriptor[i] = self.group[name].ref
+
+        # Write all the tuples if this isn't adaptive
+        if not desc.is_adaptive():
+            for i, a in enumerate(axis_names):
+                self.data[a,:] = tuples[a]
 
         # Write pointer
         w_idx = 0
@@ -256,9 +261,10 @@ class WriteToHDF5(Filter):
                     self.data[s.descriptor.data_name, w_idx:w_idx+d.size] = d
                 
                 # Write the coordinate tuples
-                tuples = desc.tuples()
-                for axis_name in axis_names:
-                    self.data[axis_name, w_idx:w_idx+d.size] = tuples[axis_name][w_idx:w_idx+d.size]
+                if desc.is_adaptive():
+                    tuples = desc.tuples()
+                    for axis_name in axis_names:
+                        self.data[axis_name, w_idx:w_idx+d.size] = tuples[axis_name][w_idx:w_idx+d.size]
 
                 self.file.flush()
                 w_idx += message_data[0].size

--- a/src/auspex/filters/io.py
+++ b/src/auspex/filters/io.py
@@ -224,7 +224,7 @@ class WriteToHDF5(Filter):
             # If we receive a message
             if message_type == 'event':
                 logger.debug('%s "%s" received event "%s"', self.__class__.__name__, self.name, message_data)
-                if messages[0]['data'] == 'done':
+                if messages[0]['event_type'] == 'done':
                     break
 
             elif message_type == 'data':
@@ -276,13 +276,6 @@ class WriteToHDF5(Filter):
 
                 logger.debug("HDF5: Write index at %d", w_idx)
                 logger.debug("HDF5: %s has written %d points", stream.name, w_idx)
-
-        # try:
-        #     self.file.close()
-        #     self.file = None
-        # except:
-        #     # This doesn't seem to happen when we don't used named columns
-        #     logger.debug("Ignoring 'dictionary changed sized during iteration' error.")
 
 class DataBuffer(Filter):
     """Writes data to file."""

--- a/src/auspex/filters/io.py
+++ b/src/auspex/filters/io.py
@@ -103,7 +103,7 @@ class WriteToHDF5(Filter):
         stream     = streams[0]
 
         for s in streams[1:]:
-            if not np.all(s.descriptor.tuples() == streams[0].descriptor.tuples()):
+            if not np.all(s.descriptor.expected_tuples() == streams[0].descriptor.expected_tuples()):
                 raise ValueError("Multiple streams connected to writer must have matching descriptors.")
 
         desc       = stream.descriptor
@@ -128,7 +128,7 @@ class WriteToHDF5(Filter):
 
         # Extend the dtypes for each data column
         for stream in streams:
-            dtype.append((desc.data_name, desc.dtype))
+            dtype.append((stream.descriptor.data_name, desc.dtype))
 
         logger.debug("Data type for HDF5: %s", dtype)
         if self.compress:

--- a/src/auspex/stream.py
+++ b/src/auspex/stream.py
@@ -274,6 +274,8 @@ class DataStreamDescriptor(object):
         return dtype
 
     def tuples(self, as_structured_array=True):
+        """Returns a list of all tuples visited by the sweeper. Should only
+        be used with adaptive sweeps."""
         if as_structured_array:
             # If we already have a structured array
             if type(self.visited_tuples) is np.ndarray and type(self.visited_tuples.dtype.names) is tuple:
@@ -282,8 +284,10 @@ class DataStreamDescriptor(object):
         return self.visited_tuples
 
     def expected_tuples(self, with_metadata=False, as_structured_array=True):
+        """Returns a list of tuples representing the cartesian product of the axis values. Should only
+        be used with non-adaptive sweeps."""
         vals           = [a.points_with_metadata() for a in self.axes]
-        nested_list    = list(itertools.product(*vals))
+        nested_list    = itertools.product(*vals)
         flattened_list = [tuple((val for sublist in line for val in sublist)) for line in nested_list]
         if as_structured_array:
             return np.core.records.fromrecords(flattened_list, dtype=self.axis_data_type(with_metadata=True))

--- a/src/auspex/stream.py
+++ b/src/auspex/stream.py
@@ -22,7 +22,7 @@ from auspex.log import logger
 
 class DataAxis(object):
     """An axis in a data stream"""
-    def __init__(self, name, points=[], unit=None, metadata=None):
+    def __init__(self, name, points=[], unit=None, metadata=None, dtype=np.float32):
         super(DataAxis, self).__init__()
         if isinstance(name, list):
             self.unstructured = True
@@ -45,6 +45,7 @@ class DataAxis(object):
         self.original_points = self.points
         self.has_been_extended = False
         self.num_new_points = 0
+        self.dtype         = dtype
 
         if self.unstructured:
             if unit is not None and len(name) != len(unit):

--- a/src/auspex/stream.py
+++ b/src/auspex/stream.py
@@ -162,10 +162,13 @@ class SweepAxis(DataAxis):
                     self.done = True
                     self.reset()
                     logger.debug("Sweep Axis '{}' complete.".format(self.name))
+                    return False
+                return True
             else:
                 self.step = 0
                 self.done = True
                 logger.debug("Sweep Axis '{}' complete.".format(self.name))
+                return False
 
     def push(self):
         """ Push parameter value(s) """
@@ -404,8 +407,8 @@ class DataStream(object):
         # and also should support sending via zmq.
         await self.queue.put(message)
 
-    async def push_event(self, event):
-        message = {"type": "event", "compression": "none", "data": event}
+    async def push_event(self, event_type, data=None):
+        message = {"type": "event", "compression": "none", "event_type": event_type, "data": data}
         await self.queue.put(message)
 
     async def push_direct(self, data):
@@ -502,6 +505,10 @@ class OutputConnector(object):
             self.points_taken += len(data)
         for stream in self.output_streams:
             await stream.push(data)
+
+    async def push_event(self, event_type, data=None):
+        for stream in self.output_streams:
+            await stream.push_event(event_type, data)
 
     def __repr__(self):
         return "<OutputConnector(name={})>".format(self.name)

--- a/src/auspex/stream.py
+++ b/src/auspex/stream.py
@@ -130,9 +130,9 @@ class SweepAxis(DataAxis):
         self.metadata    = metadata
         self.experiment  = None # Should be explicitly set by the experiment
 
-        # Pathological case here — I hope nobody requests this
-        if self.metadata and self.refine_func:
-            raise Exception("Pathological use case! Please do not attempt to use adaptive sweeps with metadata.")
+        # # Pathological case here — I hope nobody requests this
+        # if self.metadata and self.refine_func:
+        #     raise Exception("Pathological use case! Please do not attempt to use adaptive sweeps with metadata.")
 
         if self.unstructured and len(parameter) != len(points[0]):
             raise ValueError("Parameter value tuples must be the same length as the number of parameters.")

--- a/src/auspex/stream.py
+++ b/src/auspex/stream.py
@@ -117,6 +117,10 @@ class SweepAxis(DataAxis):
             super(SweepAxis, self).__init__(parameter.name, points, unit=parameter.unit)
             self.value     = points[0]
 
+        # Current value of the metadata
+        if self.metadata:
+            self.metadata_value = self.metadata[0]
+
         # This is run at the end of this sweep axis
         # Refine_func receives the sweep axis and the experiment as arguments
         self.refine_func = refine_func
@@ -130,10 +134,6 @@ class SweepAxis(DataAxis):
         self.metadata    = metadata
         self.experiment  = None # Should be explicitly set by the experiment
 
-        # # Pathological case here — I hope nobody requests this
-        # if self.metadata and self.refine_func:
-        #     raise Exception("Pathological use case! Please do not attempt to use adaptive sweeps with metadata.")
-
         if self.unstructured and len(parameter) != len(points[0]):
             raise ValueError("Parameter value tuples must be the same length as the number of parameters.")
 
@@ -145,8 +145,9 @@ class SweepAxis(DataAxis):
         if self.step < self.num_points():
             if self.callback_func:
                 self.callback_func(self, self.experiment)
-            # print(f"Axis {self.name} being set to {self.points[self.step]} of {self.points}")
             self.value = self.points[self.step]
+            if self.metadata:
+                self.metadata_value = self.metadata[self.step]
             logger.debug("Sweep Axis '{}' at step {} takes value: {}.".format(self.name,
                                                                                self.step,self.value))
             self.push()

--- a/src/auspex/sweep.py
+++ b/src/auspex/sweep.py
@@ -43,8 +43,11 @@ class Sweeper(object):
         return [a.value for a in self.axes]
 
     async def check_for_refinement(self):
+        refined_axes = []
         for a in self.axes:
-            await a.check_for_refinement()
+            if await a.check_for_refinement():
+                refined_axes.append(a.name)
+        return refined_axes
 
     def done(self):
         return np.all([a.done for a in self.axes])

--- a/src/auspex/sweep.py
+++ b/src/auspex/sweep.py
@@ -43,11 +43,16 @@ class Sweeper(object):
         # reversed list since we store "innermost" axes last.
         values = []
         for a in self.axes[::-1]:
-            if type(a.value) in [np.ndarray, list]:
-                values.append(tuple(a.value)) 
+            if a.metadata:
+                if type(a.value) in [np.ndarray, list]:
+                    values.append(tuple(list(a.value) + [a.metadata_value])) 
+                else:
+                    values.append((a.value, a.metadata_value))
             else:
-                values.append((a.value,))
-        # print("Sweeper returning values:", values)
+                if type(a.value) in [np.ndarray, list]:
+                    values.append(tuple(a.value)) 
+                else:
+                    values.append((a.value,))
         return values
 
     async def check_for_refinement(self):

--- a/src/auspex/sweep.py
+++ b/src/auspex/sweep.py
@@ -39,15 +39,21 @@ class Sweeper(object):
                 await self.axes[j].update()
         
         # At this point all of the updates should have happened
-        # return the current coordinates of the sweep.
-        return [a.value for a in self.axes]
+        # return the current coordinates of the sweep. Return the 
+        # reversed list since we store "innermost" axes last.
+        return [a.value for a in self.axes[::-1]]
 
     async def check_for_refinement(self):
         refined_axes = []
         for a in self.axes:
             if await a.check_for_refinement():
                 refined_axes.append(a.name)
-        return refined_axes
+        if len(refined_axes) > 1:
+            raise Exception("More than one axis trying to refine simultaneously. This cannot be tolerated.")
+        elif len(refined_axes) == 1:
+            return refined_axes[0]
+        else:
+            return None
 
     def done(self):
         return np.all([a.done for a in self.axes])

--- a/src/auspex/sweep.py
+++ b/src/auspex/sweep.py
@@ -55,6 +55,9 @@ class Sweeper(object):
                     values.append((a.value,))
         return values
 
+    def is_adaptive(self):
+        return True in [a.refine_func is not None for a in self.axes]
+
     async def check_for_refinement(self):
         refined_axes = []
         for a in self.axes:

--- a/src/auspex/sweep.py
+++ b/src/auspex/sweep.py
@@ -29,7 +29,7 @@ class Sweeper(object):
         imax = len(self.axes)-1
         if imax < 0:
             logger.debug("There are no sweep axis, only data axes.")
-            return True
+            return None
         else:
             i=0
             while i<imax and self.axes[i].step==0:
@@ -37,6 +37,10 @@ class Sweeper(object):
             # Need to update parameters from outer --> inner axis
             for j in range(i,-1,-1):
                 await self.axes[j].update()
+        
+        # At this point all of the updates should have happened
+        # return the current coordinates of the sweep.
+        return [a.value for a in self.axes]
 
     async def check_for_refinement(self):
         for a in self.axes:

--- a/src/auspex/sweep.py
+++ b/src/auspex/sweep.py
@@ -41,7 +41,14 @@ class Sweeper(object):
         # At this point all of the updates should have happened
         # return the current coordinates of the sweep. Return the 
         # reversed list since we store "innermost" axes last.
-        return [a.value for a in self.axes[::-1]]
+        values = []
+        for a in self.axes[::-1]:
+            if type(a.value) in [np.ndarray, list]:
+                values.append(tuple(a.value)) 
+            else:
+                values.append((a.value,))
+        # print("Sweeper returning values:", values)
+        return values
 
     async def check_for_refinement(self):
         refined_axes = []

--- a/test/test_adapt_1d.py
+++ b/test/test_adapt_1d.py
@@ -64,12 +64,9 @@ class Adapt1DTestCase(unittest.TestCase):
         exp.set_graph(edges)
 
         async def rf(sweep_axis, exp):
-            # logger.debug("Waiting for writer to catch up...")
-            # await asyncio.sleep(0.5)
-            # return False
             logger.debug("Running refinement function.")
-            temps = wr.data['temperature']
-            ress  = wr.data['resistance']
+            temps = wr.group['data']['temperature'][:]
+            ress  = wr.group['data']['resistance'][:]
             logger.debug("Temps: {}".format(temps))
             logger.debug("Ress: {}".format(ress))
 

--- a/test/test_adapt_1d.py
+++ b/test/test_adapt_1d.py
@@ -24,10 +24,6 @@ from auspex.filters.io import WriteToHDF5
 from auspex.log import logger
 from auspex.analysis.io import load_from_HDF5
 
-import logging
-logger.setLevel(logging.INFO)
-
-
 
 class SweptTestExperiment(Experiment):
     """Here the run loop merely spews data until it fills up the stream. """

--- a/test/test_average.py
+++ b/test/test_average.py
@@ -20,8 +20,7 @@ from auspex.stream import DataStream, DataAxis, DataStreamDescriptor, OutputConn
 from auspex.filters.debug import Print, Passthrough
 from auspex.filters.io import DataBuffer
 from auspex.filters.average import Averager
-from auspex.log import logger, logging
-logger.setLevel(logging.INFO)
+from auspex.log import logger
 
 class TestExperiment(Experiment):
 

--- a/test/test_buffer.py
+++ b/test/test_buffer.py
@@ -22,9 +22,6 @@ from auspex.filters.debug import Print
 from auspex.filters.io import DataBuffer
 from auspex.log import logger
 
-import logging
-logger.setLevel(logging.INFO)
-
 class SweptTestExperiment(Experiment):
     """Here the run loop merely spews data until it fills up the stream. """
 

--- a/test/test_correlator.py
+++ b/test/test_correlator.py
@@ -14,8 +14,7 @@ from auspex.stream import DataStream, DataAxis, DataStreamDescriptor, OutputConn
 from auspex.filters.debug import Print, Passthrough
 from auspex.filters.correlator import Correlator
 from auspex.filters.io import DataBuffer
-from auspex.log import logger, logging
-logger.setLevel(logging.INFO)
+from auspex.log import logger
 
 class CorrelatorExperiment(Experiment):
 

--- a/test/test_experiment.py
+++ b/test/test_experiment.py
@@ -22,8 +22,7 @@ from auspex.parameter import FloatParameter
 from auspex.stream import DataStream, DataAxis, DataStreamDescriptor, OutputConnector
 from auspex.filters.debug import Print, Passthrough
 from auspex.filters.average import Averager
-from auspex.log import logger, logging
-logger.setLevel(logging.INFO)
+from auspex.log import logger
 
 class TestInstrument1(SCPIInstrument):
     frequency = FloatCommand(get_string="frequency?", set_string="frequency {:g}", value_range=(0.1, 10))

--- a/test/test_sweeps.py
+++ b/test/test_sweeps.py
@@ -22,9 +22,6 @@ from auspex.filters.debug import Print
 from auspex.filters.io import WriteToHDF5
 from auspex.log import logger
 
-import logging
-logger.setLevel(logging.INFO)
-
 class SweptTestExperiment(Experiment):
     """Here the run loop merely spews data until it fills up the stream. """
 

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -166,13 +166,13 @@ class WriteTestCase(unittest.TestCase):
         exp.run_sweeps()
         self.assertTrue(os.path.exists("test_writehdf5-0000.h5"))
         with h5py.File("test_writehdf5-0000.h5", 'r') as f:
-            self.assertTrue(0.0 not in f['main']['data']['voltage'])
-            self.assertTrue(np.sum(f['main']['data']['field']) == 5*3*np.sum(np.linspace(0,100.0,4)) )
-            self.assertTrue(np.sum(f['main']['data']['freq']) == 5*4*np.sum(np.linspace(0,10.0,3)) )
-            self.assertTrue(np.sum(f['main']['data']['samples']) == 3*4*np.sum(np.linspace(0,4,5)) )
+            self.assertTrue(0.0 not in f['main/data/voltage'])
+            self.assertTrue(np.sum(f['main/data/field']) == 5*3*np.sum(np.linspace(0,100.0,4)) )
+            self.assertTrue(np.sum(f['main/data/freq']) == 5*4*np.sum(np.linspace(0,10.0,3)) )
+            self.assertTrue(np.sum(f['main/data/samples']) == 3*4*np.sum(np.linspace(0,4,5)) )
             self.assertTrue("Here the run loop merely spews" in f.attrs['exp_src'])
-            self.assertTrue(f['main']['data'].attrs['time_val'] == 0)
-            self.assertTrue(f['main']['data'].attrs['unit_freq'] == "Hz")
+            self.assertTrue(f['main/data'].attrs['time_val'] == 0)
+            self.assertTrue(f['main/data'].attrs['unit_freq'] == "Hz")
 
         os.remove("test_writehdf5-0000.h5")
 
@@ -190,16 +190,16 @@ class WriteTestCase(unittest.TestCase):
         exp.run_sweeps()
         self.assertTrue(os.path.exists("test_writehdf5_metadata-0000.h5"))
         with h5py.File("test_writehdf5_metadata-0000.h5", 'r') as f:
-            self.assertTrue(0.0 not in f['main']['data']['voltage'])
-            self.assertTrue(np.sum(f['main']['data']['field']) == 5*3*np.sum(np.linspace(0,100.0,4)) )
-            self.assertTrue(np.sum(f['main']['data']['freq']) == 5*4*np.sum(np.linspace(0,10.0,3)) )
-            self.assertTrue(np.sum(np.isnan(f['main']['data']['samples'])) == 3*4*2 )
-            self.assertTrue(np.sum(f['main']['data']['samples_metadata'][:] == 'data') == 4*3*3)
+            self.assertTrue(0.0 not in f['main/data']['voltage'])
+            self.assertTrue(np.sum(f['main/data/field']) == 5*3*np.sum(np.linspace(0,100.0,4)) )
+            self.assertTrue(np.sum(f['main/data/freq']) == 5*4*np.sum(np.linspace(0,10.0,3)) )
+            self.assertTrue(np.sum(np.isnan(f['main/data/samples'])) == 3*4*2 )
+            self.assertTrue(np.sum(f['main/data/samples_metadata'][:] == 'data') == 4*3*3)
             self.assertTrue("Here the run loop merely spews" in f.attrs['exp_src'])
-            self.assertTrue(f['main']['data'].attrs['time_val'] == 0)
-            self.assertTrue(f['main']['data'].attrs['unit_freq'] == "Hz")
-            self.assertTrue('metadata' in f['main']['samples'].attrs)
-            self.assertTrue(f[f['main']['samples'].attrs['metadata']] == f['main']['samples_metadata'])
+            self.assertTrue(f['main/data'].attrs['time_val'] == 0)
+            self.assertTrue(f['main/data'].attrs['unit_freq'] == "Hz")
+            self.assertTrue('metadata' in f['main/samples'].attrs)
+            self.assertTrue(f[f['main/samples'].attrs['metadata']] == f['main/samples_metadata'])
         os.remove("test_writehdf5_metadata-0000.h5")
 
     def test_writehdf5_metadata_unstructured(self):
@@ -227,16 +227,16 @@ class WriteTestCase(unittest.TestCase):
         exp.run_sweeps()
         self.assertTrue(os.path.exists("test_writehdf5_metadata_unstructured-0000.h5"))
         with h5py.File("test_writehdf5_metadata_unstructured-0000.h5", 'r') as f:
-            self.assertTrue(0.0 not in f['main']['data']['voltage'])
-            self.assertTrue(np.sum(np.isnan(f['main']['data']['field'])) == 3*5 )
-            self.assertTrue(np.sum(np.isnan(f['main']['data']['freq'])) == 3*5 )
-            self.assertTrue(np.sum(np.isnan(f['main']['data']['samples'])) == 3*4*2 )
-            self.assertTrue(np.sum(f['main']['data']['field+freq_metadata'][:] == 'a') == 5)
-            self.assertTrue(np.sum(f['main']['data']['field+freq_metadata'][:] == 'b') == 5)
-            self.assertTrue(np.sum(f['main']['data']['field+freq_metadata'][:] == 'c') == 5)
+            self.assertTrue(0.0 not in f['main/data/voltage'])
+            self.assertTrue(np.sum(np.isnan(f['main/data/field'])) == 3*5 )
+            self.assertTrue(np.sum(np.isnan(f['main/data/freq'])) == 3*5 )
+            self.assertTrue(np.sum(np.isnan(f['main/data/samples'])) == 3*4*2 )
+            self.assertTrue(np.sum(f['main/data/field+freq_metadata'][:] == 'a') == 5)
+            self.assertTrue(np.sum(f['main/data/field+freq_metadata'][:] == 'b') == 5)
+            self.assertTrue(np.sum(f['main/data/field+freq_metadata'][:] == 'c') == 5)
             self.assertTrue("Here the run loop merely spews" in f.attrs['exp_src'])
-            self.assertTrue(f['main']['data'].attrs['time_val'] == 0)
-            self.assertTrue(f['main']['data'].attrs['unit_freq'] == "Hz")
+            self.assertTrue(f['main/data'].attrs['time_val'] == 0)
+            self.assertTrue(f['main/data'].attrs['unit_freq'] == "Hz")
 
         os.remove("test_writehdf5_metadata_unstructured-0000.h5")
 
@@ -275,16 +275,16 @@ class WriteTestCase(unittest.TestCase):
         exp.run_sweeps()
         self.assertTrue(os.path.exists("test_writehdf5_metadata_unstructured_adaptive-0000.h5"))
         with h5py.File("test_writehdf5_metadata_unstructured_adaptive-0000.h5", 'r') as f:
-            self.assertTrue(0.0 not in f['main']['data']['voltage'])
-            self.assertTrue(np.sum(np.isnan(f['main']['data']['field'])) == 3*5 )
-            self.assertTrue(np.sum(np.isnan(f['main']['data']['freq'])) == 3*5 )
-            self.assertTrue(np.sum(np.isnan(f['main']['data']['samples'])) == 3*4*2 )
-            self.assertTrue(np.sum(f['main']['data']['field+freq_metadata'][:] == 'a') == 5)
-            self.assertTrue(np.sum(f['main']['data']['field+freq_metadata'][:] == 'b') == 5)
-            self.assertTrue(np.sum(f['main']['data']['field+freq_metadata'][:] == 'c') == 5)
+            self.assertTrue(0.0 not in f['main/data']['voltage'])
+            self.assertTrue(np.sum(np.isnan(f['main/data/field'])) == 3*5 )
+            self.assertTrue(np.sum(np.isnan(f['main/data/freq'])) == 3*5 )
+            self.assertTrue(np.sum(np.isnan(f['main/data/samples'])) == 3*4*2 )
+            self.assertTrue(np.sum(f['main/data/field+freq_metadata'][:] == 'a') == 5)
+            self.assertTrue(np.sum(f['main/data/field+freq_metadata'][:] == 'b') == 5)
+            self.assertTrue(np.sum(f['main/data/field+freq_metadata'][:] == 'c') == 5)
             self.assertTrue("Here the run loop merely spews" in f.attrs['exp_src'])
-            self.assertTrue(f['main']['data'].attrs['time_val'] == 0)
-            self.assertTrue(f['main']['data'].attrs['unit_freq'] == "Hz")
+            self.assertTrue(f['main/data'].attrs['time_val'] == 0)
+            self.assertTrue(f['main/data'].attrs['unit_freq'] == "Hz")
 
         os.remove("test_writehdf5_metadata_unstructured_adaptive-0000.h5")
 
@@ -304,18 +304,18 @@ class WriteTestCase(unittest.TestCase):
         self.assertTrue(os.path.exists("test_samefile_writehdf5-0000.h5"))
         with h5py.File("test_samefile_writehdf5-0000.h5", 'r') as f:
             self.assertTrue(0.0 not in f['group1']['data']['voltage'])
-            self.assertTrue(np.sum(f['group1']['data']['field']) == 5*3*np.sum(np.linspace(0,100.0,4)) )
-            self.assertTrue(np.sum(f['group1']['data']['freq']) == 5*4*np.sum(np.linspace(0,10.0,3)) )
-            self.assertTrue(np.sum(f['group1']['data']['samples']) == 3*4*np.sum(np.linspace(0,4,5)) )
+            self.assertTrue(np.sum(f['group1/data/field']) == 5*3*np.sum(np.linspace(0,100.0,4)) )
+            self.assertTrue(np.sum(f['group1/data/freq']) == 5*4*np.sum(np.linspace(0,10.0,3)) )
+            self.assertTrue(np.sum(f['group1/data/samples']) == 3*4*np.sum(np.linspace(0,4,5)) )
             self.assertTrue("Here the run loop merely spews" in f.attrs['exp_src'])
-            self.assertTrue(f['group1']['data'].attrs['time_val'] == 0)
-            self.assertTrue(f['group1']['data'].attrs['unit_freq'] == "Hz")
-            self.assertTrue(0.0 not in f['group2']['data']['current'])
-            self.assertTrue(np.sum(f['group2']['data']['field']) == 3*np.sum(np.linspace(0,100.0,4)) )
-            self.assertTrue(np.sum(f['group2']['data']['freq']) == 4*np.sum(np.linspace(0,10.0,3)) )
+            self.assertTrue(f['group1/data'].attrs['time_val'] == 0)
+            self.assertTrue(f['group1/data'].attrs['unit_freq'] == "Hz")
+            self.assertTrue(0.0 not in f['group2/data/current'])
+            self.assertTrue(np.sum(f['group2/data/field']) == 3*np.sum(np.linspace(0,100.0,4)) )
+            self.assertTrue(np.sum(f['group2/data/freq']) == 4*np.sum(np.linspace(0,10.0,3)) )
             self.assertTrue("Here the run loop merely spews" in f.attrs['exp_src'])
-            self.assertTrue(f['group2']['data'].attrs['time_val'] == 0)
-            self.assertTrue(f['group2']['data'].attrs['unit_freq'] == "Hz")
+            self.assertTrue(f['group2/data'].attrs['time_val'] == 0)
+            self.assertTrue(f['group2/data'].attrs['unit_freq'] == "Hz")
 
         os.remove("test_samefile_writehdf5-0000.h5")
 
@@ -335,12 +335,12 @@ class WriteTestCase(unittest.TestCase):
         exp.run_sweeps()
         self.assertTrue(os.path.exists("test_writehdf5_complex-0000.h5"))
         with h5py.File("test_writehdf5_complex-0000.h5", 'r') as f:
-            self.assertTrue(0.0 not in f['main']['data']['voltage'])
-            self.assertTrue(np.sum(f['main']['data']['field']) == 5*3*np.sum(np.linspace(0,100.0,4)) )
-            self.assertTrue(np.sum(f['main']['data']['freq']) == 5*4*np.sum(np.linspace(0,10.0,3)) )
-            self.assertTrue(np.sum(f['main']['data']['samples']) == 3*4*np.sum(np.linspace(0,4,5)) )
-            self.assertTrue(f['main']['data'].attrs['time_val'] == 0)
-            self.assertTrue(f['main']['data'].attrs['unit_freq'] == "Hz")
+            self.assertTrue(0.0 not in f['main/data/voltage'])
+            self.assertTrue(np.sum(f['main/data/field']) == 5*3*np.sum(np.linspace(0,100.0,4)) )
+            self.assertTrue(np.sum(f['main/data/freq']) == 5*4*np.sum(np.linspace(0,10.0,3)) )
+            self.assertTrue(np.sum(f['main/data/samples']) == 3*4*np.sum(np.linspace(0,4,5)) )
+            self.assertTrue(f['main/data'].attrs['time_val'] == 0)
+            self.assertTrue(f['main/data'].attrs['unit_freq'] == "Hz")
 
         os.remove("test_writehdf5_complex-0000.h5")
 
@@ -357,12 +357,12 @@ class WriteTestCase(unittest.TestCase):
         exp.run_sweeps()
         self.assertTrue(os.path.exists("test_writehdf5_mult-0000.h5"))
         with h5py.File("test_writehdf5_mult-0000.h5", 'r') as f:
-            self.assertTrue(0.0 not in f['main']['data']['voltage'])
-            self.assertTrue(np.sum(f['main']['data']['field']) == 5*3*np.sum(np.linspace(0,100.0,4)) )
-            self.assertTrue(np.sum(f['main']['data']['freq']) == 5*4*np.sum(np.linspace(0,10.0,3)) )
-            self.assertTrue(np.sum(f['main']['data']['samples']) == 3*4*np.sum(np.linspace(0,4,5)) )
-            self.assertTrue(f['main']['data'].attrs['time_val'] == 0)
-            self.assertTrue(f['main']['data'].attrs['unit_freq'] == "Hz")
+            self.assertTrue(0.0 not in f['main/data/voltage'])
+            self.assertTrue(np.sum(f['main/data/field']) == 5*3*np.sum(np.linspace(0,100.0,4)) )
+            self.assertTrue(np.sum(f['main/data/freq']) == 5*4*np.sum(np.linspace(0,10.0,3)) )
+            self.assertTrue(np.sum(f['main/data/samples']) == 3*4*np.sum(np.linspace(0,4,5)) )
+            self.assertTrue(f['main/data'].attrs['time_val'] == 0)
+            self.assertTrue(f['main/data'].attrs['unit_freq'] == "Hz")
 
         os.remove("test_writehdf5_mult-0000.h5")
 
@@ -389,9 +389,9 @@ class WriteTestCase(unittest.TestCase):
         exp.run_sweeps()
         self.assertTrue(os.path.exists("test_writehdf5_adaptive-0000.h5"))
         self.assertTrue(wr.points_taken == 5*11*5)
-        
+
         with h5py.File("test_writehdf5_adaptive-0000.h5", 'r') as f:
-            self.assertTrue(f['main']['data']['freq'][:].sum() == (55*(1+2+4+8+16)))
+            self.assertTrue(f['main/data/freq'][:].sum() == (55*(1+2+4+8+16)))
 
         os.remove("test_writehdf5_adaptive-0000.h5")
 
@@ -420,8 +420,8 @@ class WriteTestCase(unittest.TestCase):
         self.assertTrue(wr.points_taken == 10*5)
 
         with h5py.File("test_writehdf5_unstructured-0000.h5", 'r') as f:
-            self.assertTrue(f[f['main']['field+freq'][0]] == f['main']['field'])
-            self.assertTrue(f[f['main']['field+freq'][1]] == f['main']['freq'])
+            self.assertTrue(f[f['main/field+freq'][0]] == f['main/field'])
+            self.assertTrue(f[f['main/field+freq'][1]] == f['main/freq'])
 
         data, desc = load_from_HDF5("test_writehdf5_unstructured-0000.h5")
         self.assertTrue(data['main']['field'][-5:].sum() == 5*68)

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -384,10 +384,11 @@ class WriteTestCase(unittest.TestCase):
         exp.run_sweeps()
         self.assertTrue(os.path.exists("test_writehdf5_adaptive-0000.h5"))
         self.assertTrue(wr.points_taken == 5*11*5)
+        
         with h5py.File("test_writehdf5_adaptive-0000.h5", 'r') as f:
-            self.assertTrue(len(f['main']['freq']) == 5)
+            self.assertTrue(f['main']['data']['freq'].sum() == (55*(1+2+4+8+16)))
 
-        os.remove("test_writehdf5_adaptive-0000.h5")
+        # os.remove("test_writehdf5_adaptive-0000.h5")
 
     def test_writehdf5_unstructured_sweep(self):
         exp = SweptTestExperiment()

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -21,6 +21,7 @@ from auspex.parameter import FloatParameter
 from auspex.stream import DataStream, DataAxis, DataStreamDescriptor, OutputConnector
 from auspex.filters.debug import Print
 from auspex.filters.io import WriteToHDF5
+from auspex.analysis.io import load_from_HDF5
 from auspex.log import logger
 
 class SweptTestExperiment(Experiment):
@@ -421,6 +422,9 @@ class WriteTestCase(unittest.TestCase):
         with h5py.File("test_writehdf5_unstructured-0000.h5", 'r') as f:
             self.assertTrue(f[f['main']['field+freq'][0]] == f['main']['field'])
             self.assertTrue(f[f['main']['field+freq'][1]] == f['main']['freq'])
+
+        data, desc = load_from_HDF5("test_writehdf5_unstructured-0000.h5")
+        self.assertTrue(data['main']['field'][-5:].sum() == 5*68)
 
         os.remove("test_writehdf5_unstructured-0000.h5")
 

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -23,9 +23,6 @@ from auspex.filters.debug import Print
 from auspex.filters.io import WriteToHDF5
 from auspex.log import logger
 
-import logging
-logger.setLevel(logging.INFO)
-
 class SweptTestExperiment(Experiment):
     """Here the run loop merely spews data until it fills up the stream. """
 

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -346,7 +346,6 @@ class WriteTestCase(unittest.TestCase):
 
         edges = [(exp.voltage, wr.sink), (exp.current, wr.sink)]
         exp.set_graph(edges)
-
         exp.add_sweep(exp.field, np.linspace(0,100.0,4))
         exp.add_sweep(exp.freq, np.linspace(0,10.0,3))
         exp.run_sweeps()
@@ -388,7 +387,7 @@ class WriteTestCase(unittest.TestCase):
         with h5py.File("test_writehdf5_adaptive-0000.h5", 'r') as f:
             self.assertTrue(f['main']['data']['freq'].sum() == (55*(1+2+4+8+16)))
 
-        os.remove("test_wsritehdf5_adaptive-0000.h5")
+        os.remove("test_writehdf5_adaptive-0000.h5")
 
     def test_writehdf5_unstructured_sweep(self):
         exp = SweptTestExperiment()

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -279,7 +279,6 @@ class WriteTestCase(unittest.TestCase):
             self.assertTrue("Here the run loop merely spews" in f.attrs['exp_src'])
             self.assertTrue(f['main']['data'].attrs['time_val'] == 0)
             self.assertTrue(f['main']['data'].attrs['unit_freq'] == "Hz")
-            self.assertTrue(len(f['main']['field+freq']) == 12)
 
         os.remove("test_writehdf5_metadata_unstructured_adaptive-0000.h5")
 

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -388,7 +388,7 @@ class WriteTestCase(unittest.TestCase):
         with h5py.File("test_writehdf5_adaptive-0000.h5", 'r') as f:
             self.assertTrue(f['main']['data']['freq'].sum() == (55*(1+2+4+8+16)))
 
-        # os.remove("test_writehdf5_adaptive-0000.h5")
+        os.remove("test_wsritehdf5_adaptive-0000.h5")
 
     def test_writehdf5_unstructured_sweep(self):
         exp = SweptTestExperiment()


### PR DESCRIPTION
**Substantial changes to how auspex handles sweeping, filtering, and writing in particular:**
1. For adaptive sweeps, the sweeper emits "visited tuples" as it iterates over the axes. This works seamlessly for adaptive sweeps, since the emission continues until an axis is deemed finished by the refinement function.
1. **Filters are now responsible for pushing their own version of visited tuples if they are going to function with adaptive sweeps.** This can be rather complicated (e.g. for the averaging filter we must drop the averaged column, reshape, and slice based on the averaging dimensions)
1. For "fixed" sweeps, the tuples are treated as they were before, and a rectilinear itertools.product of the various descriptor axes is sufficient to reconstruct all of the visited tuples.
1. **The HDF5 writer has abandoned compound datasets in favor of individual columns**. This makes compatibility with other HDF5 implementations much more straightforward. Reconstruction of descriptors is more explicit, and we use attributes and references to deal with associating metadata and unstructured axis information.

