### PR TITLE
Copy current json files with data

### DIFF
--- a/src/auspex/filters/io.py
+++ b/src/auspex/filters/io.py
@@ -31,7 +31,7 @@ class WriteToHDF5(Filter):
     filename = FilenameParameter()
     groupname = Parameter(default='main')
 
-    def __init__(self, filename=None, groupname=None, add_date=False, save_settings=True, compress=True, **kwargs):
+    def __init__(self, filename=None, groupname=None, add_date=False, save_settings=False, compress=True, **kwargs):
         super(WriteToHDF5, self).__init__(**kwargs)
         self.compress = compress
         if filename:


### PR DESCRIPTION
Simplest approach to save current experimental settings. It could be also done at `QubitExpFactory.create`, but we may want to save the settings only if the experiment is actually run.

Note that this doesn't save settings changed ad hoc for the run, for example in [calibration](https://github.com/BBN-Q/Auspex/blob/d3b72f55e22a22bb7eeea70030a7711083b27364/src/auspex/pulse_calibration.py#L61).
 
Check box to be added in PyQlab. 
