### PR TITLE
Multiple plotters / X6 phys. chan.

### DIFF
--- a/src/auspex/exp_factory.py
+++ b/src/auspex/exp_factory.py
@@ -150,8 +150,6 @@ class QubitExpFactory(object):
 
                 instrument_settings['instrDict'][dig_name]['nbr_segments'] = num_segments
 
-                plotters = [e for e in endpoints if measurement_settings["filterDict"][e]["x__class__"] == "Plotter" and
-                                                   measurement_settings["filterDict"][e]["enabled"]]
                 if plotters:
                     plotter_ancestors = set().union(*[nx.ancestors(dag, pl) for pl in plotters])
                     plotter_ancestors.remove(dig_name)


### PR DESCRIPTION
Allow plotting, e.g., both demodulated and raw streams in the same physical
channel. Previously, only the channel set as receiver was enabled.
Multiple writers are also in principle possible, but still not allowed.