### PR TITLE
Sweep pulse amplitude through AWG channels

### DIFF
--- a/src/auspex/exp_factory.py
+++ b/src/auspex/exp_factory.py
@@ -460,17 +460,17 @@ class QubitExpFactory(object):
                     # We are sweeping a qubit, so we must lookup the instrument
                     name, meas_or_control, prop = par["target"].split()
                     qubit = qubits[name]
+                    method_name = "set_{}".format(prop.lower())
 
-                    # We should allow for either mixed up signals or direct synthesis
-                    if 'generator' in qubit[meas_or_control]:
+                    # If sweeping frequency, we should allow for either mixed up signals or direct synthesis.
+                    # Sweeping power is always through the AWG channels.
+                    if 'generator' in qubit[meas_or_control] and prop.lower() == "frequency":
                         name = qubit[meas_or_control]['generator']
                         instr = experiment._instruments[name]
-                        method_name = 'set_' + prop.lower()
                     else:
                         # Construct a function that sets a per-channel property
                         name, chan = qubit[meas_or_control]['AWG'].split()
                         instr = experiment._instruments[name]
-                        method_name = "set_{}".format(prop.lower())
                         
                         def method(value, channel=chan, instr=instr, prop=prop.lower()):
                             # e.g. keysight.set_amplitude("ch1", 0.5)
@@ -534,7 +534,7 @@ class QubitExpFactory(object):
         # Find out which output connectors we need to create
         # ==================================================
 
-        # Get the enabled measurements, or those which aren't explicitlu 
+        # Get the enabled measurements, or those which aren't explicitly
         enabled_meas = {k: v for k, v in experiment.settings['filters'].items() if 'enabled' not in v or v['enabled'] }
 
         # First look for digitizer streams (Alazar or X6)

--- a/src/auspex/instruments/bbn.py
+++ b/src/auspex/instruments/bbn.py
@@ -192,7 +192,6 @@ class APS2(Instrument, metaclass=MakeSettersGetters):
         else:
             self.wrapper = aps2.APS2()
 
-        self.set_amplitude = self.wrapper.set_channel_scale
         self.set_offset    = self.wrapper.set_channel_offset
         self.set_enabled   = self.wrapper.set_channel_enabled
         self.set_mixer_phase_skew = self.wrapper.set_mixer_phase_skew
@@ -228,6 +227,13 @@ class APS2(Instrument, metaclass=MakeSettersGetters):
             self.stop()
             self.wrapper.disconnect()
             self.connected = False
+
+    def set_amplitude(self, chs, value):
+        if isinstance(chs, int) or len(chs)==1:
+            self.wrapper.set_channel_scale(int(chs), value)
+        else:
+            self.wrapper.set_channel_scale(int(chs[0])-1, value)
+            self.wrapper.set_channel_scale(int(chs[1])-1, value)
 
     def set_all(self, settings_dict, prefix=""):
         # Pop the channel settings


### PR DESCRIPTION
Allow `add_qubit_sweep('q1 measure amplitude', ...)` by sweeping both AWG quadratures. My take in merging [this](https://github.com/BBN-Q/Auspex/commit/805ed41c8e4b53654b53a1bd75bf0e4fc90285d3) and [that](https://github.com/BBN-Q/Auspex/commit/488eb34bd392ad644fa626d06c0ba15ddaaa2301).