### PR TITLE
Build tree for single-shot fidelity measurements

### DIFF
--- a/src/auspex/config.py
+++ b/src/auspex/config.py
@@ -40,6 +40,8 @@ class Include():
     def write(self):
         with open(self.filename, 'w') as fid:
             yaml.dump(self.data, fid, Dumper=yaml.RoundTripDumper)
+    def pop(self, key):
+        return self.data.pop(key)
 
 class Loader(yaml.RoundTripLoader):
     def __init__(self, stream):

--- a/src/auspex/exp_factory.py
+++ b/src/auspex/exp_factory.py
@@ -141,7 +141,7 @@ class QubitExpFactory(object):
         return exp
 
     @staticmethod
-    def create(meta_file=None, expname=None, calibration=False, cw_mode=False, repeats=None):
+    def create(meta_file=None, expname=None, calibration=False, save_data = True, cw_mode=False, repeats=None):
         """Create the experiment, but do not run the sweeps. If *cw_mode* is specified
         the AWGs will be operated in continuous waveform mode, and will not be stopped
         and started between succesive sweep points. The *calibration* argument is used
@@ -157,10 +157,11 @@ class QubitExpFactory(object):
         # This is generally the behavior we want
         auspex.globals.single_plotter_mode = True
 
-        # Instantiaite and perform all of our setup
+        # Instantiate and perform all of our setup
         experiment = QubitExperiment()
         experiment.settings        = settings
         experiment.calibration     = calibration
+        experiment.save_data       = save_data
         experiment.name            = expname
         experiment.cw_mode         = cw_mode
         experiment.calibration     = calibration
@@ -183,12 +184,20 @@ class QubitExpFactory(object):
         objects."""
 
         calibration = experiment.calibration
+        save_data = experiment.save_data
 
         # Create a mapping from qubits to data writers and inverse
         qubit_to_writer     = {}
         writer_to_qubit     = {}
         qubit_to_stream_sel = {}
         stream_sel_to_qubit = {}
+
+        # shortcuts
+        instruments = experiment.settings['instruments']
+        filters     = experiment.settings['filters']
+        qubits      = experiment.settings['qubits']
+        if 'sweeps' in experiment.settings:
+            sweeps      = experiment.settings['sweeps']
 
         # Use the meta info to modify the parameters
         # loaded from the human-friendly yaml configuration.
@@ -208,24 +217,33 @@ class QubitExpFactory(object):
             return vals[0]
 
         # Graph edges for the measurement filters
-        edges = [(strip_conn_name(v["source"]), k) for k,v in experiment.settings["filters"].items() if ("enabled" not in v.keys()) or v["enabled"]]
+        # switch stream selector to raw (by default) before building the graph
+        if isinstance(experiment, auspex.single_shot_fidelity.SingleShotFidelityExperiment):
+            receivers = [s for s in meta_info['receivers'].items()]
+            if len(receivers) > 1:
+                raise NotImplementedError("Single shot fidelity for more than one qubit is not yet implemented.")
+            stream_sel_name_orig = receivers[0][0].replace('RecvChan-', '')
+            X6_stream_selectors = [k for k,v in filters.items() if v["type"] == 'X6StreamSelector' and v["source"] == filters[stream_sel_name_orig]['source']]
+            for s in X6_stream_selectors:
+                if filters[s]['stream_type'] == experiment.ss_stream_type:
+                    filters[s]['enabled'] = True
+                    stream_sel_name = s
+                else:
+                    filters[s]['enabled'] = False
+
+        edges = [(strip_conn_name(v["source"]), k) for k,v in filters.items() if ("enabled" not in v.keys()) or v["enabled"]]
         dag = nx.DiGraph()
         dag.add_edges_from(edges)
 
         inst_to_enable = []
         filt_to_enable = []
 
-        # Laziness
-        instruments = experiment.settings['instruments']
-        filters     = experiment.settings['filters']
-        qubits      = experiment.settings['qubits']
-        if 'sweeps' in experiment.settings:
-            sweeps      = experiment.settings['sweeps']
-
         # Find any writer endpoints of the receiver channels
         for receiver_name, num_segments in meta_info['receivers'].items():
             # Receiver channel name format: RecvChan-StreamSelectorName
-            stream_sel_name = receiver_name.replace('RecvChan-', '')
+            if not isinstance(experiment, auspex.single_shot_fidelity.SingleShotFidelityExperiment):
+                stream_sel_name = receiver_name.replace('RecvChan-', '')
+                stream_sel_name_orig = stream_sel_name
             dig_name = filters[stream_sel_name]['source']
             chan_name = filters[stream_sel_name]['channel']
 
@@ -233,7 +251,7 @@ class QubitExpFactory(object):
                 num_segments *= experiment.repeats
 
             # Set the correct number of segments for the digitizer
-            experiment.settings["instruments"][dig_name]['nbr_segments'] = num_segments
+            instruments[dig_name]['nbr_segments'] = num_segments
 
             # Enable the digitizer
             inst_to_enable.append(dig_name)
@@ -241,46 +259,52 @@ class QubitExpFactory(object):
             # Set number of segments in the digitizer
             instruments[dig_name]['nbr_segments'] = num_segments
 
-            # Find the descendants tree for the receiver channels
+            # Enable the tree for single-shot fidelity experiment. Change stream_sel_name to raw (by default)
             writers = []
             plotters = []
+            singleshot = []
             for filt_name, filt in filters.items():
                 if filt_name == stream_sel_name:
                     # Find descendants of the channel selector
                     chan_descendants = nx.descendants(dag, filt_name)
                     # Find endpoints within the descendants
                     endpoints = [n for n in chan_descendants if dag.in_degree(n) == 1 and dag.out_degree(n) == 0]
-                    # Find endpoints which are enabled writers
+                    # Find endpoints which are enabled writers, plotters or singleshot filters
                     writers += [e for e in endpoints if filters[e]["type"] == "WriteToHDF5" and (not hasattr(filters[e], "enabled") or filters[e]["enabled"])]
                     plotters += [e for e in endpoints if filters[e]["type"] == "Plotter" and (not hasattr(filters[e], "enabled") or filters[e]["enabled"])]
-            filt_to_enable.extend(set().union(writers, plotters))
+                    singleshot += [e for e in endpoints if filters[e]["type"] == "SingleShotMeasurement" and (not hasattr(filters[e], "enabled") or filters[e]["enabled"]) and isinstance(experiment, auspex.single_shot_fidelity.SingleShotFidelityExperiment)]
+            filt_to_enable.extend(set().union(writers, plotters, singleshot))
             if calibration:
                 # For calibrations the user should only have one writer enabled, otherwise we will be confused.
                 if len(writers) > 1:
-                    raise Exception("More than one viable data writer was found for a receiver channel {}. Please enabled only one!".format(receiver_name))
-                if len(writers) == 0 and len(plotters) == 0:
-                    raise Exception("No viable data writer or plotter was found for receiver channel {}. Please enabled only one!".format(receiver_name))
+                    raise Exception("More than one viable data writer was found for a receiver channel {}. Please enable only one!".format(receiver_name))
+                if len(writers) == 0 and len(plotters) == 0 and len(singleshot) == 0:
+                    raise Exception("No viable data writer, plotter or single-shot filter was found for receiver channel {}. Please enable one!".format(receiver_name))
 
+            if writers and not save_data:
                 # If we are calibrating we don't care about storing data, use buffers instead
                 buffers = []
                 for w in writers:
-                    label = filters[w]["label"]
+                    source_filt = filters[w]["source"].split(" ")[0]
+                    if filters[source_filt]["type"] == "Averager":
+                        sources = ", ".join([source_filt + " final_average", source_filt + " final_variance"])
+                    else:
+                        sources = filters[w]["source"]
                     buff = {
-                            "source": filters[w]["source"],
+                            "source": sources,
                             "enabled": True,
-                            "label": label,
                             "type": "DataBuffer",
                             }
                     # Remove the writer
-                    filters.pop(filters[w]["label"])
+                    filters.pop(w)
                     # Substitute the buffer
-                    filters[label] = buff
+                    filters[w] = buff
                     # Store buffer name for local use
-                    buffers.append(label)
+                    buffers.append(w)
                 writers = buffers
 
             # For now we assume a single qubit, not a big change for multiple qubits
-            qubit_name = next(k for k, v in qubits.items() if v["measure"]["receiver"] == stream_sel_name)
+            qubit_name = next(k for k, v in qubits.items() if v["measure"]["receiver"] in (stream_sel_name, stream_sel_name_orig))
             if calibration:
                 if len(writers) == 1:
                     qubit_to_writer[qubit_name] = writers[0]
@@ -288,22 +312,22 @@ class QubitExpFactory(object):
                 qubit_to_writer[qubit_name] = writers
 
             if calibration:
+                writer_ancestors = []
+                plotter_ancestors = []
+                singleshot_ancestors = []
                 # Trace back our ancestors, using plotters if no writers are available
                 if len(writers) == 1:
-                    useful_output_filter_ancestors = nx.ancestors(dag, writers[0])
-                else:
-                    useful_output_filter_ancestors = nx.ancestors(dag, plotters[0])
-
-                # We will have gotten the digitizer, which should be removed since we're already taking care of it
-                useful_output_filter_ancestors.remove(dig_name)
-
+                    writer_ancestors = nx.ancestors(dag, writers[0])
+                    # We will have gotten the digitizer, which should be removed since we're already taking care of it
+                    writer_ancestors.remove(dig_name)
                 if plotters:
                     plotter_ancestors = set().union(*[nx.ancestors(dag, pl) for pl in plotters])
                     plotter_ancestors.remove(dig_name)
-                else:
-                    plotter_ancestors = []
+                if singleshot:
+                    singleshot_ancestors = set().union(*[nx.ancestors(dag, ss) for ss in singleshot])
+                    singleshot_ancestors.remove(dig_name)
 
-                filt_to_enable.extend(set().union(useful_output_filter_ancestors, plotter_ancestors))
+                filt_to_enable.extend(set().union(writer_ancestors, plotter_ancestors, singleshot_ancestors))
 
         if calibration:
             # One to one writers to qubits
@@ -318,32 +342,32 @@ class QubitExpFactory(object):
         # Disable digitizers and APSs and then build ourself back up with the relevant nodes
         for instr_name in instruments.keys():
             if 'tx_channels' in instruments[instr_name].keys() or 'rx_channels' in instruments[instr_name].keys():
-                experiment.settings["instruments"][instr_name]['enabled'] = False
+                instruments[instr_name]['enabled'] = False
         for instr_name in inst_to_enable:
-            experiment.settings["instruments"][instr_name]['enabled'] = True
+            instruments[instr_name]['enabled'] = True
 
         if calibration:
             for meas_name in filters.keys():
-                experiment.settings['filters'][meas_name]['enabled'] = False
+                filters[meas_name]['enabled'] = False
             for meas_name in filt_to_enable:
-                experiment.settings['filters'][meas_name]['enabled'] = True
+                filters[meas_name]['enabled'] = True
         else:
             #label measurement with qubit name (assuming the convention "M-"+qubit_name)
             for meas_name in filt_to_enable:
-                if experiment.settings['filters'][meas_name]["type"] == "WriteToHDF5":
-                    experiment.settings['filters'][meas_name]['groupname'] = writer_to_qubit[meas_name] \
-                        + "-" + experiment.settings['filters'][meas_name]['groupname']
+                if filters[meas_name]["type"] == "WriteToHDF5":
+                    filters[meas_name]['groupname'] = writer_to_qubit[meas_name] \
+                        + "-" + filters[meas_name]['groupname']
 
         for instr_name, chan_data in meta_info['instruments'].items():
-            experiment.settings["instruments"][instr_name]['enabled']  = True
+            instruments[instr_name]['enabled']  = True
             if isinstance(chan_data, str):
-                experiment.settings["instruments"][instr_name]['seq_file'] = chan_data # Per-instrument seq file
+                instruments[instr_name]['seq_file'] = chan_data # Per-instrument seq file
             elif isinstance(chan_data, dict):
                 for chan_name, seq_file in chan_data.items():
-                    if "tx_channels" in experiment.settings["instruments"][instr_name] and chan_name in experiment.settings["instruments"][instr_name]["tx_channels"].keys():
-                        experiment.settings["instruments"][instr_name]["tx_channels"][chan_name]['seq_file'] = seq_file
-                    elif "rx_channels" in experiment.settings["instruments"][instr_name] and chan_name in experiment.settings["instruments"][instr_name]["rx_channels"].keys():
-                        experiment.settings["instruments"][instr_name]["rx_channels"][chan_name]['seq_file'] = seq_file
+                    if "tx_channels" in instruments[instr_name] and chan_name in instruments[instr_name]["tx_channels"].keys():
+                        instruments[instr_name]["tx_channels"][chan_name]['seq_file'] = seq_file
+                    elif "rx_channels" in instruments[instr_name] and chan_name in instruments[instr_name]["rx_channels"].keys():
+                        instruments[instr_name]["rx_channels"][chan_name]['seq_file'] = seq_file
                     else:
                         raise ValueError("Could not find channel {} in of instrument {}.".format(chan_name, instr_name))
 

--- a/src/auspex/pulse_calibration.py
+++ b/src/auspex/pulse_calibration.py
@@ -54,7 +54,7 @@ class PulseCalibration(object):
 
     def set(self, instrs_to_set = []):
         meta_file = compile_to_hardware(self.sequence(), fileName=self.filename, axis_descriptor=self.axis_descriptor)
-        self.exp = QubitExpFactory.create(meta_file=meta_file, calibration=True, cw_mode=self.cw_mode)
+        self.exp = QubitExpFactory.create(meta_file=meta_file, calibration=True, save_data=False, cw_mode=self.cw_mode)
         if self.plot:
             # Add the manual plotter and the update method to the experiment
             self.exp.add_manual_plotter(self.plot)

--- a/src/auspex/single_shot_fidelity.py
+++ b/src/auspex/single_shot_fidelity.py
@@ -109,11 +109,6 @@ class SingleShotFidelityExperiment(QubitExperiment):
             logger.info(f"Set digitizer {d} round robins to 1 for single shot experiment.")
             self.settings['instruments'][d]['nbr_round_robins'] = 1
 
-    def _check_for_single_shot_filter(self):
-        """Make sure there is at least one single shot measurement filter in the pipeline."""
-        if not any([type(x) is SingleShotMeasurement for x in self.filters.values()]):
-            raise NameError("There do not appear to be any single-shot measurements in your filter pipeline. Please add one!")
-
     def find_single_shot_filter(self):
         """Make sure there is one single shot measurement filter in the pipeline."""
         ssf = [x for x in self.filters.values() if type(x) is SingleShotMeasurement]

--- a/src/auspex/single_shot_fidelity.py
+++ b/src/auspex/single_shot_fidelity.py
@@ -26,7 +26,7 @@ from auspex.analysis.helpers import normalize_data
 class SingleShotFidelityExperiment(QubitExperiment):
     """Experiment to measure single-shot measurement fidelity of a qubit."""
 
-    def __init__(self, qubit_names, num_shots=10000, expname=None, meta_file=None, save_data=False):
+    def __init__(self, qubit_names, num_shots=10000, expname=None, meta_file=None, save_data=False, stream_type = 'Raw'):
         """Create a single shot fidelity measurement experiment. Assumes that there is a single shot measurement
         filter in the filter pipeline.
         Arguments:
@@ -41,10 +41,12 @@ class SingleShotFidelityExperiment(QubitExperiment):
         self.qubit     = [QubitFactory(qubit_name) for qubit_name in qubit_names] if isinstance(qubit_names, list) else QubitFactory(qubit_names)
 
         self.settings = config.yaml_load(config.configFile)
-        self.calibration = save_data
+        self.save_data = save_data
+        self.calibration = True
         self.name = expname
         self.cw_mode = False
         self.repeats = num_shots
+        self.ss_stream_type = stream_type
 
         if meta_file is None:
             meta_file = SingleShot(self.qubit)
@@ -57,7 +59,7 @@ class SingleShotFidelityExperiment(QubitExperiment):
         QubitExpFactory.load_filters(self)
         if 'sweeps' in self.settings:
             QubitExpFactory.load_parameter_sweeps(experiment)
-        self._check_for_single_shot_filter()
+        self.ssf = self.find_single_shot_filter()
         self.leave_plot_server_open = True
 
     def run_sweeps(self):
@@ -112,12 +114,20 @@ class SingleShotFidelityExperiment(QubitExperiment):
         if not any([type(x) is SingleShotMeasurement for x in self.filters.values()]):
             raise NameError("There do not appear to be any single-shot measurements in your filter pipeline. Please add one!")
 
-    def get_results(self):
-        """Get the PDF and fidelity numbers from the filters. Returns a dictionary of PDF data with the
-        filter names as keys."""
+    def find_single_shot_filter(self):
+        """Make sure there is one single shot measurement filter in the pipeline."""
         ssf = [x for x in self.filters.values() if type(x) is SingleShotMeasurement]
         if len(ssf) > 1:
             raise NotImplementedError("Single shot fidelity for more than one qubit is not yet implemented.")
+        elif len(ssf) == 0:
+            raise NameError("There do not appear to be any single-shot measurements in your filter pipeline. Please add one!")
+        return ssf
+
+    def get_results(self):
+        """Get the PDF and fidelity numbers from the filters. Returns a dictionary of PDF data with the
+        filter names as keys."""
+        ssf = self.find_single_shot_filter()
+        if len(ssf) > 1:
             try:
                 return {x.name: x.pdf_data for x in ssf}
             except AttributeError:


### PR DESCRIPTION
Only enable relevant filters. Main changes:
* Set every `SingleShotFidelityExperiment.calibration = True` to deal with filters as a separate set compared to standard measurements. Ideally, no need to manually disable/enable filters, just as for a pulse calibration. 
* Add new parameter `experiment.save_data` to decide whether endpoints are either writers or buffers.
* Allow to choose a different `SingleShotFidelityExperiment.stream_type` at exp. creation. Default type is `Raw`. 