### PR TITLE
Simplify load/set complex kernels

### DIFF
--- a/config/config.example.json
+++ b/config/config.example.json
@@ -1,4 +1,5 @@
 {
 	"AWGDir": "/my/path/to/AWG/",
+	"kernelDir": "/my/path/to/kernels/",
 	"ConfigurationFile": "/my/path/to/measure.yml"
 }

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -1,5 +1,5 @@
 {
 	"AWGDir": "/my/path/to/AWG/",
-	"kernelDir": "/my/path/to/kernels/",
+	"KernelDir": "/my/path/to/kernels/",
 	"ConfigurationFile": "/my/path/to/measure.yml"
 }

--- a/src/auspex/config.py
+++ b/src/auspex/config.py
@@ -97,10 +97,12 @@ else:
 # abspath allows the use of relative file names in the config file
 AWGDir = os.path.abspath(cfg['AWGDir'])
 configFile = os.path.abspath(cfg['ConfigurationFile'])
+KernelDir = os.path.abspath(cfg['KernelDir'])
+
 try:
     import QGL.config
     AWGDir = QGL.config.AWGDir
     configFile = QGL.config.configFile
+    KernelDir = QGL.config.KernelDir
 except:
     pass
-

--- a/src/auspex/config.py
+++ b/src/auspex/config.py
@@ -103,6 +103,5 @@ try:
     import QGL.config
     AWGDir = QGL.config.AWGDir
     configFile = QGL.config.configFile
-    KernelDir = QGL.config.KernelDir
 except:
     pass

--- a/src/auspex/filters/singleshot.py
+++ b/src/auspex/filters/singleshot.py
@@ -19,7 +19,9 @@ from .filter import Filter
 from auspex.parameter import Parameter, FloatParameter, IntParameter, BoolParameter
 from auspex.stream import DataStreamDescriptor, InputConnector, OutputConnector, SweepAxis
 from auspex.log import logger
+import auspex.config as config
 import time
+import os
 
 class SingleShotMeasurement(Filter):
 
@@ -266,7 +268,7 @@ class SingleShotMeasurement(Filter):
         try:
             filename = self.sink.parent.name + "_kernel.txt"
             header = f'Single shot fidelity filter - {time.strftime("%m/%d/%y -- %H:%M")}:\nSource: {self.sink.parent.name}'
-            np.savetxt(filename, self.kernel, header=header, comments="#")
+            np.savetxt(os.path.join(config.KernelDir, filename), self.kernel, header=header, comments="#")
         except (AttributeError, IOError) as ex:
             raise AttributeError("Could not save single shot fidelity kernel!") from ex
 

--- a/src/auspex/instruments/X6.py
+++ b/src/auspex/instruments/X6.py
@@ -14,9 +14,11 @@ import struct
 import datetime
 import asyncio
 import numpy as np
+import os
 
 import auspex.globals
 from auspex.log import logger
+import auspex.config as config
 from .instrument import Instrument, DigitizerChannel
 from unittest.mock import MagicMock
 
@@ -56,7 +58,8 @@ class X6Channel(DigitizerChannel):
         for name, value in settings_dict.items():
 
             if name == "kernel" and isinstance(value, str) and value:
-                self.kernel = eval(value)
+                #assume that the kernel is saved as a complex array
+                self.kernel = np.loadtxt(os.path.join(config.KernelDir, value+'.txt'), dtype=complex, converters={0: lambda s: complex(s.decode().replace('+-', '-'))})
             elif name == "kernel_bias" and isinstance(value, str) and value:
                 self.kernel_bias = eval(value)
             #elif hasattr(self, name):
@@ -67,7 +70,7 @@ class X6Channel(DigitizerChannel):
                 try:
                     setattr(self, name, value)
                 except AttributeError:
-                    logger.debug(f"Could not set channel attirbute: {name} on X6 {self.stream_type} channel.")
+                    logger.debug(f"Could not set channel attribute: {name} on X6 {self.stream_type} channel.")
                     pass
 
         if self.stream_type == "Integrated":


### PR DESCRIPTION
Simplify the loading of complex kernels, as saved in
 https://github.com/BBN-Q/Auspex/blob/79de22a59ee1f6fb4aa472f7769a07cb0e6f7932/src/auspex/filters/singleshot.py#L269

using a `kernelDir` set in `config.json`.

This allows specifying the kernel simply as 

kernel: kernel_name

in the integrated filter attributes. E.g.:

```
q1-Kernel:
  type: X6StreamSelector
  stream_type: Integrated
  source: X6
  channel: 1
  dsp_channel: 1
  kernel: SingleShotMeasurement 1_kernel
  enabled: true
```
