### PR TITLE
WIP: Plot servers and processes

### DIFF
--- a/src/auspex/exp_factory.py
+++ b/src/auspex/exp_factory.py
@@ -244,6 +244,7 @@ class QubitExpFactory(object):
         logger.info("Found first pass I offset of {}.".format(I1_offset))
         mce.I_offset.value = I1_offset
 
+        mce.first_exp = False # slight misnomer to indicate that no new plot is needed
         sweep_offset("Q_offset", offset_pts)
         Q1_amps = np.array([x[1] for x in buff.get_data()])
         Q1_offset, xpts, ypts = find_null_offset(offset_pts, Q1_amps)
@@ -287,7 +288,7 @@ class QubitExpFactory(object):
         getattr(mce, cals[second_cal]).value = offset2
 
         mce.disconnect_instruments()
-        mce.plot_server.stop()
+        mce.extra_plot_server.stop()
 
         if write_to_file:
             mce.write_to_file()

--- a/src/auspex/experiment.py
+++ b/src/auspex/experiment.py
@@ -516,11 +516,12 @@ class Experiment(metaclass=MetaExperiment):
             except:
                 logger.debug("File probably already closed...")
 
-        try:
-            if len(self.plotters) > 0 and not self.leave_plot_server_open:
-                self.plot_server.stop()
-        except:
-            logger.warning("Could not stop plot server gracefully...")
+        if hasattr(self, 'plot_server'):
+            try:
+                if len(self.plotters) > 0: #and not self.leave_plot_server_open:
+                    self.plot_server.stop()
+            except:
+                logger.warning("Could not stop plot server gracefully...")
 
         self.shutdown_instruments()
 

--- a/src/auspex/experiment.py
+++ b/src/auspex/experiment.py
@@ -621,7 +621,7 @@ class Experiment(metaclass=MetaExperiment):
         else:
             auspex.globals.last_plotter_process = subprocess.Popen(['python', client_path, 'localhost'],
                                                                 env=os.environ.copy())
-        if not auspex.globals.last_extra_plotter_process or not self.leave_plot_server_open or not self.instrs_connected:
+        if hasattr(self, 'extra_plot_server') and (not auspex.globals.last_extra_plotter_process or not self.leave_plot_server_open or not self.instrs_connected):
             if hasattr(os, 'setsid'):
                 auspex.globals.last_extra_plotter_process = subprocess.Popen(['python', client_path, 'localhost', str(self.extra_plot_server.status_port), str(self.extra_plot_server.data_port)], env=os.environ.copy(), preexec_fn=os.setsid)
             else:

--- a/src/auspex/experiment.py
+++ b/src/auspex/experiment.py
@@ -450,7 +450,8 @@ class Experiment(metaclass=MetaExperiment):
         self.nodes = [n for n in self.nodes if not(hasattr(n, 'input_connectors') and        n.input_connectors['sink'].descriptor.num_dims()==0)]
 
         # Go and find any plotters
-        self.plotters = [n for n in self.nodes if isinstance(n, (Plotter, MeshPlotter, XYPlotter))]
+        self.standard_plotters = [n for n in self.nodes if isinstance(n, (Plotter, MeshPlotter, XYPlotter))]
+        self.plotters = copy.copy(self.standard_plotters)
 
         # We might have some additional plotters that are separate from
         # The asyncio filter pipeline
@@ -467,43 +468,10 @@ class Experiment(metaclass=MetaExperiment):
             if hasattr(n, 'final_init'):
                 n.final_init()
 
-        # Launch the bokeh-server if necessary.
+        # Launch plot servers.
         if len(self.plotters) > 0:
-            logger.debug("Found %d plotters", len(self.plotters))
-
-            from .plotting import MatplotServerThread
-
-            plot_desc = {p.name: p.desc() for p in self.plotters}
-            if not self.leave_plot_server_open or not hasattr(self, "plot_server"):
-                self.plot_server = MatplotServerThread(plot_desc)
-            for plotter in self.plotters:
-                plotter.plot_server = self.plot_server
-            time.sleep(0.5)
-            # Kill a previous plotter if desired.
-            if auspex.globals.single_plotter_mode and auspex.globals.last_plotter_process and not( self.keep_instruments_connected and self.instrs_connected):
-                pro = auspex.globals.last_plotter_process
-                if hasattr(os, 'setsid'): # Doesn't exist on windows
-                    try:
-                        os.kill(pro.pid, 0) # Raises an error if the PID doesn't exist
-                        os.killpg(os.getpgid(pro.pid), signal.SIGTERM) # Proceed to kill process group
-                    except OSError:
-                        logger.debug("No plotter to kill.")
-                else:
-                    try:
-                        pro.kill()
-                    except:
-                        logger.debug("No plotter to kill.")
-
-            client_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),"matplotlib-client.py")
-            if not self.keep_instruments_connected or not (auspex.globals.last_plotter_process and self.instrs_connected): #keep_instruments_connected is a flag for keeping the plot process running
-                if hasattr(os, 'setsid'):
-                    auspex.globals.last_plotter_process = subprocess.Popen(['python', client_path, 'localhost'],
-                                                                        env=os.environ.copy(), preexec_fn=os.setsid)
-                else:
-                    auspex.globals.last_plotter_process = subprocess.Popen(['python', client_path, 'localhost'],
-                                                                        env=os.environ.copy())
-            time.sleep(1)
-
+            self.init_plot_servers()
+        time.sleep(1)
         #connect all instruments
         self.connect_instruments()
         #initialize instruments
@@ -610,3 +578,51 @@ class Experiment(metaclass=MetaExperiment):
 
         stream = self._extra_plots_to_streams[plotter]
         await stream.push_direct(data)
+
+    def init_plot_servers(self):
+        logger.debug("Found %d plotters", len(self.plotters))
+
+        from .plotting import MatplotServerThread
+        import pdb; pdb.set_trace()
+        plot_desc = {p.name: p.desc() for p in self.standard_plotters}
+        extra_plot_desc = {p.name: p.desc() for p in self.extra_plotters + self.manual_plotters}
+        if not hasattr(self, "plot_server"):
+            self.plot_server = MatplotServerThread(plot_desc)
+        if len(self.plotters) != len(self.standard_plotters) and not hasattr(self, "extra_plot_server"):
+            self.extra_plot_server = MatplotServerThread(extra_plot_desc, status_port = self.plot_server.status_port+2, data_port = self.plot_server.data_port+2)
+        for plotter in self.standard_plotters:
+            plotter.plot_server = self.plot_server
+        for plotter in self.extra_plotters + self.manual_plotters:
+            plotter.plot_server = self.extra_plot_server
+        time.sleep(0.5)
+        # Kill a previous plotter if desired.
+        if auspex.globals.single_plotter_mode and auspex.globals.last_plotter_process:
+            pros = [auspex.globals.last_plotter_process]
+            if not (self.leave_plot_server_open and self.instrs_connected) and auspex.globals.last_extra_plotter_process:
+                pros += [auspex.globals.last_extra_plotter_process]
+            for pro in pros:
+                if hasattr(os, 'setsid'): # Doesn't exist on windows
+                    try:
+                        os.kill(pro.pid, 0) # Raises an error if the PID doesn't exist
+                        os.killpg(os.getpgid(pro.pid), signal.SIGTERM) # Proceed to kill process group
+                    except OSError:
+                        logger.debug("No plotter to kill.")
+                else:
+                    try:
+                        pro.kill()
+                    except:
+                        logger.debug("No plotter to kill.")
+
+        client_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),"matplotlib-client.py")
+        #if not auspex.globals.last_plotter_process:
+        if hasattr(os, 'setsid'):
+            auspex.globals.last_plotter_process = subprocess.Popen(['python', client_path, 'localhost'],
+                                                                env=os.environ.copy(), preexec_fn=os.setsid)
+        else:
+            auspex.globals.last_plotter_process = subprocess.Popen(['python', client_path, 'localhost'],
+                                                                env=os.environ.copy())
+        if not auspex.globals.last_extra_plotter_process or not self.leave_plot_server_open or not self.instrs_connected:
+            if hasattr(os, 'setsid'):
+                auspex.globals.last_extra_plotter_process = subprocess.Popen(['python', client_path, 'localhost', str(self.extra_plot_server.status_port), str(self.extra_plot_server.data_port)], env=os.environ.copy(), preexec_fn=os.setsid)
+            else:
+                auspex.globals.last_extra_plotter_process = subprocess.Popen(['python', client_path, 'localhost', str(self.extra_plot_server.status_port), str(self.extra_plot_server.data_port)], env=os.environ.copy())

--- a/src/auspex/globals.py
+++ b/src/auspex/globals.py
@@ -4,13 +4,14 @@
 # when scraping modules in Auspex)
 auspex_dummy_mode = False
 
-# If this is True, then close the last 
+# If this is True, then close the last
 # plotter before starting a new one.
 single_plotter_mode = False
 
 # This holds a reference to the most
-# recent plotter.
+# recent plotters.
 last_plotter_process = None
+last_extra_plotter_process = None
 
 # Config directory
 config_file       = None

--- a/src/auspex/pulse_calibration.py
+++ b/src/auspex/pulse_calibration.py
@@ -52,6 +52,11 @@ def calibrate(calibrations, update_settings=True):
                 calibration.exp.plot_server.stop()
             except:
                 pass
+            try:
+                print("stopping extra server")
+                calibration.exp.extra_plot_server.stop()
+            except:
+                pass
 
 
 class PulseCalibration(object):
@@ -86,13 +91,21 @@ class PulseCalibration(object):
 
     def set(self, instrs_to_set = [], **params):
         try:
-            self.exp.plot_server.stop()
+            extra_plot_server = self.exp.extra_plot_server
+            instrs_connected = self.exp.instrs_connected
         except Exception as e:
             pass #no experiment yet created, or plot server not yet started
         meta_file = compile_to_hardware(self.sequence(**params), fileName=self.filename, axis_descriptor=self.axis_descriptor)
+        if hasattr(self.exp, 'extra_plot_server'):
+            extra_plot_server = self.exp.extra_plot_server
         self.exp = QubitExpFactory.create(meta_file=meta_file, calibration=True, save_data=False, cw_mode=self.cw_mode)
         self.exp.leave_plot_server_open = True
-        self.keep_instruments_connected = True
+        self.exp.keep_instruments_connected = True
+        try:
+            self.exp.extra_plot_server = extra_plot_server
+            self.exp.instrs_connected = instrs_connected
+        except:
+            pass
         if self.plot:
             # Add the manual plotter and the update method to the experiment
             self.exp.add_manual_plotter(self.plot)

--- a/src/auspex/pulse_calibration.py
+++ b/src/auspex/pulse_calibration.py
@@ -91,10 +91,11 @@ class PulseCalibration(object):
             pass #no experiment yet created, or plot server not yet started
         meta_file = compile_to_hardware(self.sequence(**params), fileName=self.filename, axis_descriptor=self.axis_descriptor)
         self.exp = QubitExpFactory.create(meta_file=meta_file, calibration=True, save_data=False, cw_mode=self.cw_mode)
+        self.exp.leave_plot_server_open = True
+        self.keep_instruments_connected = True
         if self.plot:
             # Add the manual plotter and the update method to the experiment
             self.exp.add_manual_plotter(self.plot)
-        self.exp.connect_instruments()
         #sweep instruments for calibration
         for instr_to_set in instrs_to_set:
             par = FloatParameter()
@@ -106,7 +107,6 @@ class PulseCalibration(object):
                 raise KeyError("Sweep values not defined.")
 
     def run(self):
-        self.exp.leave_plot_server_open = True
         self.exp.run_sweeps()
         data = {}
         var = {}


### PR DESCRIPTION
Attempt to unify all the requirements for standard qubit experiments, pulse, and mixer calibrations. Mostly working, but some plot warnings to be fixed.

Start a separate plot server for the result of pulse calibrations, so that it persists between runs. After several attempts at reusing the same server for everything, this approach seems to me the most flexible and general. 