### PR TITLE
add cffi requirement

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -45,6 +45,7 @@ Which will automatically fetch and install all of the requirements. If you are u
 - pandas >= 0.18.1
 - networkx >= 1.11
 - matplotlib >= 2.0.0
+- cffi >= 1.10.0
 
 Qubit Experiments
 *****************

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -46,6 +46,7 @@ Which will automatically fetch and install all of the requirements. If you are u
 - networkx >= 1.11
 - matplotlib >= 2.0.0
 - cffi >= 1.10.0
+- scikit-learn >= 1.16 
 
 Qubit Experiments
 *****************


### PR DESCRIPTION
Seems like we require CFFI for the labbrick driver.  Is there any fell for how far back we can go on the version?  Might not need 1.10.0 but need to test this.