### PR TITLE
Save variance in hdf5

### DIFF
--- a/src/auspex/filters/average.py
+++ b/src/auspex/filters/average.py
@@ -136,6 +136,8 @@ class Averager(Filter):
 
         # Define variance axis descriptor
         descriptor_var = descriptor_in.copy()
+        if descriptor_var.dtype == np.complex128:
+            descriptor_var.dtype = np.float64
         descriptor_var.data_name = "Variance"
         descriptor_var.pop_axis(self.axis.value)
         if descriptor_var.unit:


### PR DESCRIPTION
Allow saving the variance in the same group (and subgroup) as `Data` for a given qubit. Need to connect a writer to `final_variance` with the same filename and group name (i.e., qubit) as the writer connected to `final_average`.  