### PR TITLE
Store var(real) and var(imag)

### DIFF
--- a/src/auspex/filters/average.py
+++ b/src/auspex/filters/average.py
@@ -237,7 +237,7 @@ class Averager(Filter):
                     for os in self.final_average.output_streams + self.partial_average.output_streams:
                         await os.push(reshaped.mean(axis=self.mean_axis))
                     for os in self.final_variance.output_streams:
-                        await os.push(reshaped.var(axis=self.mean_axis, ddof=1)) # N-1 in the denominator
+                        await os.push(np.real(reshaped).var(axis=self.mean_axis, ddof=1)+1j*np.imag(reshaped).var(axis=self.mean_axis, ddof=1)) # N-1 in the denominator
                     self.sum_so_far[:]        = 0.0
                     self.current_avg_frame[:] = 0.0
                     self.completed_averages   = 0

--- a/src/auspex/pulse_calibration.py
+++ b/src/auspex/pulse_calibration.py
@@ -131,7 +131,10 @@ class PulseCalibration(object):
                     buff_data = dataset['Data']
                 data[qubit_name] = self.quad_fun(buff_data)
                 if 'Variance' in dataset.dtype.names:
-                    var[qubit_name] = dataset['Variance']/descriptor.metadata["num_averages"]
+                    if self.quad in ['real', 'imag']:
+                        var[qubit_name] = self.quad_fun(dataset['Variance'])/descriptor.metadata["num_averages"]
+                    else:
+                        raise Exception('Variance of {} not available. Choose real or imag'.format(self.quad))
                 else:
                     var[qubit_name] = None
 


### PR DESCRIPTION
Previously storing `var(z) = var(Re(z)) + var(Im(z))`. Don't we want to keep `var(Re(z))` and `var(Im(z))` separately? We typically only use one quadrature or the other. This is relevant e.g. for `PhaseEstimation` and state tomography. 

Here I propose to store those as a complex number `w = var(Re(z)) + j var(Im(z))`. 

On the other hand, do we need to compute `var(abs(z))` and `var(angle(z))`?