### PR TITLE
Removing the ambiguity between configfile and config_file.

### DIFF
--- a/config/config.example.json
+++ b/config/config.example.json
@@ -2,5 +2,5 @@
 	"AWGDir": "/my/path/to/AWG/",
 	"KernelDir": "/my/path/to/kernels/",
 	"LogDir": "/my/path/to/logs",
-	"ConfigurationFile": "/my/path/to/measure.yml"
+	"MeasureFile": "/my/path/to/measure.yml"
 }

--- a/src/auspex/config.py
+++ b/src/auspex/config.py
@@ -124,10 +124,10 @@ if auspex.globals.AWGDir:
     AWGDir = os.path.abspath(auspex.globals.AWGDir)
 else:
     AWGDir = os.path.abspath(cfg['AWGDir'])
-if auspex.globals.ConfigurationFile:
-    configFile = os.path.abspath(auspex.globals.ConfigurationFile)
+if auspex.globals.MeasureFile:
+    MeasFile = os.path.abspath(auspex.globals.MeasureFile)
 else:
-    configFile = os.path.abspath(cfg['ConfigurationFile'])
+    MeasFile = os.path.abspath(cfg['MeasureFile'])
 if auspex.globals.KernelDir:
     KernelDir = os.path.abspath(auspex.globals.KernelDir)
 else:
@@ -144,6 +144,6 @@ if not os.path.isdir(LogDir):
 try:
     import QGL.config
     AWGDir = QGL.config.AWGDir
-    configFile = QGL.config.configFile
+    MeasFile = QGL.config.MeasFile
 except:
     pass

--- a/src/auspex/exp_factory.py
+++ b/src/auspex/exp_factory.py
@@ -44,11 +44,11 @@ def correct_resource_name(resource_name):
         resource_name = resource_name.replace(k, v)
     return resource_name
 
-def quince(filepath = config.configFile):
+def quince(filepath = config.MeasFile):
     if (os.name == 'nt'):
-        subprocess.Popen(['run-quince.bat', config.configFile], env=os.environ.copy())
+        subprocess.Popen(['run-quince.bat', config.MeasFile], env=os.environ.copy())
     else:
-        subprocess.Popen(['run-quince.py', config.configFile], env=os.environ.copy())
+        subprocess.Popen(['run-quince.py', config.MeasFile], env=os.environ.copy())
 
 class QubitExperiment(Experiment):
     """Experiment with a specialized run method for qubit experiments run via the QubitExpFactory."""
@@ -163,7 +163,7 @@ class QubitExpFactory(object):
         to the data directory. If *repeats* is defined this will overide the
         number of segments gleaned from the meta_info"""
 
-        settings = config.yaml_load(config.configFile)
+        settings = config.yaml_load(config.MeasFile)
 
         # This is generally the behavior we want
         auspex.globals.single_plotter_mode = True

--- a/src/auspex/filters/io.py
+++ b/src/auspex/filters/io.py
@@ -132,13 +132,13 @@ class WriteToHDF5(Filter):
         fulldir = os.path.splitext(self.filename.value)[0]
         if not os.path.exists(fulldir):
             os.makedirs(fulldir)
-            config.yaml_dump(config.yaml_load(config.configFile), os.path.join(fulldir, os.path.split(config.configFile)[1]), flatten = True)
+            config.yaml_dump(config.yaml_load(config.MeasFile), os.path.join(fulldir, os.path.split(config.MeasFile)[1]), flatten = True)
 
     def save_yaml_h5(self):
         """ Save a copy of current experiment settings in the h5 metadata"""
         header = self.file.create_group("header")
         # load them dump to get the 'include' information
-        header.attrs['settings'] = config.yaml_dump(config.yaml_load(config.configFile), flatten = True)
+        header.attrs['settings'] = config.yaml_dump(config.yaml_load(config.MeasFile), flatten = True)
 
     async def run(self):
         self.finished_processing = False

--- a/src/auspex/globals.py
+++ b/src/auspex/globals.py
@@ -16,6 +16,6 @@ last_extra_plotter_process = None
 # Config directory
 config_file       = None
 AWGDir            = None
-ConfigurationFile = None
+MeasureFile       = None
 KernelDir         = None
 LogDir            = None

--- a/src/auspex/mixer_calibration.py
+++ b/src/auspex/mixer_calibration.py
@@ -61,7 +61,7 @@ class MixerCalibrationExperiment(Experiment):
         if mixer not in ("measure", "control"):
             raise ValueError("Unknown mixer {}: must be either 'measure' or 'control'.".format(mixer))
             self.mixer = mixer
-        self.settings = config.yaml_load(config.configFile)
+        self.settings = config.yaml_load(config.MeasFile)
         sa = [name for name, settings in self.settings['instruments'].items() if settings['type'] == 'SpectrumAnalyzer']
         if len(sa) > 1:
             raise ValueError("More than one spectrum analyzer is defined in the configuration file.")
@@ -97,7 +97,7 @@ class MixerCalibrationExperiment(Experiment):
         awg_settings['tx_channels'][self.chan][self.chan[0]]['offset'] = round(self.I_offset.value, 5)
         awg_settings['tx_channels'][self.chan][self.chan[1]]['offset'] = round(self.Q_offset.value, 5)
         self.settings['instruments'][self.AWG] = awg_settings
-        config.yaml_dump(self.settings, config.configFile)
+        config.yaml_dump(self.settings, config.MeasFile)
         logger.info("Mixer calibration for {}-{} written to experiment file.".format(self.AWG, self.chan))
 
     def _set_mixer_phase(self, phase):

--- a/src/auspex/pulse_calibration.py
+++ b/src/auspex/pulse_calibration.py
@@ -67,7 +67,7 @@ class PulseCalibration(object):
         self.exp        = None
         self.axis_descriptor = None
         self.cw_mode    = False
-        self.saved_settings = config.yaml_load(config.configFile)
+        self.saved_settings = config.yaml_load(config.MeasFile)
         self.settings = deepcopy(self.saved_settings) #make a copy for used during calibration
         self.quad = quad
         if quad == "real":
@@ -157,7 +157,7 @@ class PulseCalibration(object):
 
     def update_settings(self):
         """Update calibrated YAML with calibration parameters"""
-        config.yaml_dump(self.saved_settings, config.configFile)
+        config.yaml_dump(self.saved_settings, config.MeasFile)
 
     def write_to_log(self, cal_result):
         """Log calibration result"""

--- a/src/auspex/single_shot_fidelity.py
+++ b/src/auspex/single_shot_fidelity.py
@@ -44,7 +44,7 @@ class SingleShotFidelityExperiment(QubitExperiment):
         self.qubit_names = qubit_names if isinstance(qubit_names, list) else [qubit_names]
         self.qubit     = [QubitFactory(qubit_name) for qubit_name in qubit_names] if isinstance(qubit_names, list) else QubitFactory(qubit_names)
         # make a copy of the settings to restore default
-        self.saved_settings = config.yaml_load(config.configFile)
+        self.saved_settings = config.yaml_load(config.MeasFile)
         self.settings = deepcopy(self.saved_settings)
         self.save_data = save_data
         self.calibration = True
@@ -113,7 +113,7 @@ class SingleShotFidelityExperiment(QubitExperiment):
                     else:
                         param_key[instr_tree[-1]] = opt_value
                     logger.info("Set{} to {}.".format(" ".join(str(x) for x in instr_tree),opt_value ))
-                config.yaml_dump(self.saved_settings, config.configFile)
+                config.yaml_dump(self.saved_settings, config.MeasFile)
 
     def _update_histogram_plots(self):
         pdf_data = self.get_results()

--- a/test/notatest_qubitexpfactory.py
+++ b/test/notatest_qubitexpfactory.py
@@ -19,8 +19,8 @@ auspex.globals.auspex_dummy_mode = True
 
 # config_location.config(cfg_file)
 
-# QGL.config.configFile    = cfg_file
-auspex.config.configFile = cfg_file
+# QGL.config.MeasFile    = cfg_file
+auspex.config.MeasFile = cfg_file
 auspex.config.AWGDir     = awg_dir
 
 # Create the AWG directory if it doesn't exist
@@ -31,7 +31,7 @@ from auspex.exp_factory import QubitExpFactory
 
 import QGL.config
 QGL.config.AWGDir        = awg_dir
-QGL.config.configFile    = cfg_file
+QGL.config.MeasFile    = cfg_file
 from QGL import *
 
 class QubitExpFactoryTestCase(unittest.TestCase):

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -24,7 +24,7 @@ from auspex.filters.debug import Print
 from auspex.filters.io import WriteToHDF5
 from auspex.analysis.io import load_from_HDF5
 from auspex.log import logger
-from auspex.config import configFile, yaml_load, yaml_dump
+from auspex.config import MeasFile, yaml_load, yaml_dump
 
 def clear_test_data():
     for file in glob.glob("test_*.h5"):
@@ -176,7 +176,7 @@ class WriteTestCase(unittest.TestCase):
             self.assertTrue("Here the run loop merely spews" in f.attrs['exp_src'])
             self.assertTrue(f['main/data'].attrs['time_val'] == 0)
             self.assertTrue(f['main/data'].attrs['unit_freq'] == "Hz")
-            self.assertTrue(f['header'].attrs['settings'] == yaml_dump(yaml_load(configFile), flatten = True))
+            self.assertTrue(f['header'].attrs['settings'] == yaml_dump(yaml_load(MeasFile), flatten = True))
 
         os.remove("test_writehdf5-0000.h5")
 
@@ -200,7 +200,7 @@ class WriteTestCase(unittest.TestCase):
             self.assertTrue("Here the run loop merely spews" in f.attrs['exp_src'])
             self.assertTrue(f['main/data'].attrs['time_val'] == 0)
             self.assertTrue(f['main/data'].attrs['unit_freq'] == "Hz")
-            self.assertTrue(f['header'].attrs['settings'] == yaml_dump(yaml_load(configFile), flatten = True))
+            self.assertTrue(f['header'].attrs['settings'] == yaml_dump(yaml_load(MeasFile), flatten = True))
 
         os.remove("test_writehdf5-0000.h5")
 


### PR DESCRIPTION
So...  I'm not in a hurry to have this pulled into master.  It would require manual intervention by the user to edit their config files.  That's at least how it's written now.  This is more of a OCD clean up.  I've just essentially renamed `configFile` to `Measfile` since that's really what it's pointing to.  I just submit this to you as a casual call for comment :squirrel: