### PR TITLE
Fix initial estimate for PhaseEstimation

### DIFF
--- a/src/auspex/pulse_calibration.py
+++ b/src/auspex/pulse_calibration.py
@@ -445,10 +445,10 @@ class PhaseEstimation(PulseCalibration):
 
             logger.info("Phase: %.4f Sigma: %.4f"%(phase,sigma))
             #update amplitude
-            ct+=1
             self.amplitude, done_flag = phase_to_amplitude(phase, sigma, self.amplitude, self.target, ct, self.iteration_limit)
+            ct+=1
 
-        logger.info("Found amplitude for {} calibration of: {}".format(type(self).__name__, amp))
+        logger.info("Found amplitude for {} calibration of: {}".format(type(self).__name__, self.amplitude))
         #set_chan = self.qubit_names[0] if len(self.qubit) == 1 else ChannelLibraries.EdgeFactory(*self.qubits).label
         return (set_amp, self.amplitude)
 
@@ -852,10 +852,8 @@ def phase_to_amplitude(phase, sigma, amp, target, ct, iteration_limit=5):
     if np.abs(phase_error) < 1e-2 or np.abs(phase_error/sigma) < 1 or ct > iteration_limit:
         if np.abs(phase_error) < 1e-2:
             logger.info('Reached target rotation angle accuracy');
-            amplitude = amp
         elif abs(phase_error/sigma) < 1:
             logger.info('Reached phase uncertainty limit');
-            amplitude = amp
         else:
             logger.info('Hit max iteration count');
         done_flag = 1

--- a/test/test_measure.yml
+++ b/test/test_measure.yml
@@ -24,12 +24,12 @@ qubits:
     control:
       AWG: BBNAPS2 12
       generator: Holz2
-      frequency: -49910002.0
+      frequency: -50e6
       pulse_params:
         cutoff: 2.0
         length: 7.0e-08
-        pi2Amp: 0.50045
-        piAmp: 1.0009
+        pi2Amp: 0.3
+        piAmp: 0.6
         shape_fun: drag
         drag_scaling: 0.0
         sigma: 5.0e-09
@@ -78,10 +78,10 @@ instruments:
         phase_skew: 10
         amp_factor: 0.898
         '1':
-          offset: 0.10022
+          offset: 0.1
           amplitude: 0.9
         '2':
-          offset: 0.020220000000000002
+          offset: 0.02
           amplitude: 0.8
     markers:
       12m1:
@@ -122,7 +122,7 @@ instruments:
     type: HolzworthHS9000
     address: HS9004A-009-2
     power: -10
-    frequency: 5000090023.0
+    frequency: 5000000000.0
     enabled: true
 
 filters:

--- a/test/test_pulsecal.py
+++ b/test/test_pulsecal.py
@@ -210,7 +210,7 @@ class SingleQubitCalTestCase(unittest.TestCase):
         cal.calibrate([pi_cal])
         os.remove(self.filename)
         # NOTE: expected result is from the same input fed to the routine
-        self.assertAlmostEqual(pi_cal.amplitude, amp, places=1)
+        self.assertAlmostEqual(pi_cal.amplitude, amp, places=3)
         #restore original settings
         auspex.config.dump_meas_file(self.test_settings, cfg_file)
 


### PR DESCRIPTION
The initial amplitude was > x3 the ideal value, causing the test to fail 