### PR TITLE
Fix single shot

### DIFF
--- a/src/auspex/filters/singleshot.py
+++ b/src/auspex/filters/singleshot.py
@@ -60,12 +60,6 @@ class SingleShotMeasurement(Filter):
             self.record_length = len(self.time_pts)
         except ValueError:
             raise ValueError("Single shot filter sink does not appear to have a time axis!")
-        try:
-            rr_num = self.descriptor.axis_num("round_robins")
-        except ValueError:
-            pass
-        if self.descriptor.axes[rr_num].num_points() > 1:
-            raise ValueError("Round robins for single shot filter should be set to 1!")
         self.num_segments = len(self.sink.descriptor.axes[self.descriptor.axis_num("segment")].points)
         self.ground_data = np.zeros((self.record_length, self.num_segments//2), dtype=np.complex)
         self.excited_data = np.zeros((self.record_length, self.num_segments//2), dtype=np.complex)

--- a/src/auspex/instruments/X6.py
+++ b/src/auspex/instruments/X6.py
@@ -91,7 +91,7 @@ class X6Channel(DigitizerChannel):
         else: #Raw
             demod_channel  = 0
             result_channel = 0
-            self.dtype = np.float32
+            self.dtype = np.float64
 
         self.channel_tuple = (int(self.phys_channel), int(demod_channel), int(result_channel))
 


### PR DESCRIPTION
* Revert https://github.com/BBN-Q/Auspex/commit/f7125ae68ab04df4e43d9c4a83d8fa99dabe181d (data type) until further notice
* Axis for round robins = 1 is now not-existent after https://github.com/BBN-Q/Auspex/pull/193/commits/2cc81f24aad171351d960b93000dc9f83c60e6fd