### PR TITLE
Set all kernels to the same length

### DIFF
--- a/src/auspex/instruments/X6.py
+++ b/src/auspex/instruments/X6.py
@@ -163,6 +163,20 @@ class X6(Instrument):
         # perform channel setup
         for chan in self._channels:
             self.channel_setup(chan)
+        # pad all kernels to the maximum set length, to ensure that the valid signal is emitted only when all results are ready
+        # first find longest kernel
+        integrated_channels = [chan for chan in self._channels if chan.stream_type == 'Integrated']
+        max_kernel_length = max([len(chan.kernel) for chan in integrated_channels])
+        # pad kernes to the maximum length
+        for chan in integrated_channels:
+            if len(chan.kernel) < max_kernel_length:
+                np.append(chan.kernel, 1j*np.zeros(max_kernel_length - len(chan.kernel)))
+        # then zero disabled channels
+        enabled_int_chan_tuples = [chan.channel_tuple for chan in integrated_channels]
+        for a in range(1,3):
+            for c in range(1,3): # max number of sdp_channels for now
+                if (a, 0, c) not in enabled_int_chan_tuples:
+                    self._lib.write_kernel(a, 0, c, 1j*np.zeros(max_kernel_length))
 
     def channel_setup(self, channel):
         a, b, c = channel.channel_tuple

--- a/src/auspex/instruments/X6.py
+++ b/src/auspex/instruments/X6.py
@@ -166,17 +166,18 @@ class X6(Instrument):
         # pad all kernels to the maximum set length, to ensure that the valid signal is emitted only when all results are ready
         # first find longest kernel
         integrated_channels = [chan for chan in self._channels if chan.stream_type == 'Integrated']
-        max_kernel_length = max([len(chan.kernel) for chan in integrated_channels])
-        # pad kernes to the maximum length
-        for chan in integrated_channels:
-            if len(chan.kernel) < max_kernel_length:
-                np.append(chan.kernel, 1j*np.zeros(max_kernel_length - len(chan.kernel)))
-        # then zero disabled channels
-        enabled_int_chan_tuples = [chan.channel_tuple for chan in integrated_channels]
-        for a in range(1,3):
-            for c in range(1,3): # max number of sdp_channels for now
-                if (a, 0, c) not in enabled_int_chan_tuples:
-                    self._lib.write_kernel(a, 0, c, 1j*np.zeros(max_kernel_length))
+        if integrated_channels:
+            max_kernel_length = max([len(chan.kernel) for chan in integrated_channels])
+            # pad kernes to the maximum length
+            for chan in integrated_channels:
+                if len(chan.kernel) < max_kernel_length:
+                    np.append(chan.kernel, 1j*np.zeros(max_kernel_length - len(chan.kernel)))
+            # then zero disabled channels
+            enabled_int_chan_tuples = [chan.channel_tuple for chan in integrated_channels]
+            for a in range(1,3):
+                for c in range(1,3): # max number of sdp_channels for now
+                    if (a, 0, c) not in enabled_int_chan_tuples:
+                        self._lib.write_kernel(a, 0, c, 1j*np.zeros(max_kernel_length))
 
     def channel_setup(self, channel):
         a, b, c = channel.channel_tuple


### PR DESCRIPTION
Integrated streams need to have kernels with equal lengths. This is to
prevent the valid signal to fire too early (before all measurements are
complete).

This might be done more generally in hardware, but this should work. 