### PR TITLE
Account for TDM

### DIFF
--- a/src/auspex/instruments/bbn.py
+++ b/src/auspex/instruments/bbn.py
@@ -607,5 +607,18 @@ class APS2(Instrument, metaclass=MakeSettersGetters):
         return self.wrapper.get_fpga_temperature()
 
 class TDM(APS2):
+    """BBN TDM"""
+    instrument_type = "AWG"
+
+    yaml_template = """
+        APS2-Name:
+          type: TDM                # Used by Auspex. TDMPattern for QGL not yet available
+          enabled: true            # true or false, optional
+          address:                 # IP address or hostname should be fine
+          trigger_interval: 0.0    # (s)
+          trigger_source: Internal # Internal, Software, or System
+          seq_file: test.h5        # optional sequence file"""
+
     def set_all(self, settings_dict):
         super(APS2, self).set_all(settings_dict)
+        self.master = False # only for APS2. To make the TDM the master, set trigger_source: Internal for TDM and System for all the APS2

--- a/src/auspex/instruments/bbn.py
+++ b/src/auspex/instruments/bbn.py
@@ -605,3 +605,7 @@ class APS2(Instrument, metaclass=MakeSettersGetters):
     @property
     def fpga_temperature(self):
         return self.wrapper.get_fpga_temperature()
+
+class TDM(APS2):
+    def set_all(self, settings_dict):
+        super(APS2, self).set_all(settings_dict)

--- a/src/auspex/instruments/bbn.py
+++ b/src/auspex/instruments/bbn.py
@@ -498,7 +498,7 @@ class APS2(Instrument, metaclass=MakeSettersGetters):
     def set_all(self, settings_dict, prefix=""):
         # Pop the channel settings
         settings = deepcopy(settings_dict)
-        if 'tx_channels' in settings:
+        if 'tx_channels' in settings: # identify a TDM
             quad_channels = settings.pop('tx_channels')
         # Call the non-channel commands
         super(APS2, self).set_all(settings)

--- a/src/auspex/instruments/bbn.py
+++ b/src/auspex/instruments/bbn.py
@@ -498,32 +498,30 @@ class APS2(Instrument, metaclass=MakeSettersGetters):
     def set_all(self, settings_dict, prefix=""):
         # Pop the channel settings
         settings = deepcopy(settings_dict)
-        if 'tx_channels' in settings:
-            quad_channels = settings.pop('tx_channels')
+        quad_channels = settings.pop('tx_channels')
         # Call the non-channel commands
         super(APS2, self).set_all(settings)
 
-        if 'tx_channels' in settings:
-            # Mandatory arguments
-            for key in ['address', 'seq_file', 'trigger_interval', 'trigger_source', 'master']:
-                if key not in settings.keys():
-                    raise ValueError("Instrument {} configuration lacks mandatory key {}".format(self, key))
+        # Mandatory arguments
+        for key in ['address', 'seq_file', 'trigger_interval', 'trigger_source', 'master']:
+            if key not in settings.keys():
+                raise ValueError("Instrument {} configuration lacks mandatory key {}".format(self, key))
 
-            # We expect a dictionary of channel names and their properties
-            main_quad_dict = quad_channels.pop('12', None)
-            if not main_quad_dict:
-                raise ValueError("APS2 {} expected to receive quad channel '12'".format(self))
+        # We expect a dictionary of channel names and their properties
+        main_quad_dict = quad_channels.pop('12', None)
+        if not main_quad_dict:
+            raise ValueError("APS2 {} expected to receive quad channel '12'".format(self))
 
-            # Set the properties of individual hardware channels (offset, amplitude)
-            for chan_num, chan_name in enumerate(['1', '2']):
-                chan_dict = main_quad_dict.pop(chan_name, None)
-                if not chan_dict:
-                    raise ValueError("Could not find channel {} in quadrature channel 12 in settings for {}".format(chan_name, self))
-                for chan_attr, value in chan_dict.items():
-                    try:
-                        getattr(self, 'set_' + chan_attr)(chan_num, value)
-                    except AttributeError:
-                        pass
+        # Set the properties of individual hardware channels (offset, amplitude)
+        for chan_num, chan_name in enumerate(['1', '2']):
+            chan_dict = main_quad_dict.pop(chan_name, None)
+            if not chan_dict:
+                raise ValueError("Could not find channel {} in quadrature channel 12 in settings for {}".format(chan_name, self))
+            for chan_attr, value in chan_dict.items():
+                try:
+                    getattr(self, 'set_' + chan_attr)(chan_num, value)
+                except AttributeError:
+                    pass
 
     def load_waveform(self, channel, data):
         if channel not in (1, 2):

--- a/src/auspex/instruments/bbn.py
+++ b/src/auspex/instruments/bbn.py
@@ -498,7 +498,7 @@ class APS2(Instrument, metaclass=MakeSettersGetters):
     def set_all(self, settings_dict, prefix=""):
         # Pop the channel settings
         settings = deepcopy(settings_dict)
-        if 'tx_channels' in settings: # identify a TDM
+        if 'tx_channels' in settings:
             quad_channels = settings.pop('tx_channels')
         # Call the non-channel commands
         super(APS2, self).set_all(settings)


### PR DESCRIPTION
Currently the only way to distinguish a TDM from an APS is if there are no associated channel settings. That keeps the TDM enabled [here](https://github.com/BBN-Q/Auspex/blob/e07563ac12001a18efc1c9f0b39cf285092c4221/src/auspex/exp_factory.py#L514-L515), but we need to take care of the missing settings (this commit). 

Long term we may want to have a different class for the TDM?