### PR TITLE
Single out calibration axis for metadata

### DIFF
--- a/src/auspex/exp_factory.py
+++ b/src/auspex/exp_factory.py
@@ -548,16 +548,19 @@ class QubitExpFactory(object):
             #ovverride data axis with repeated number of segments
             data_axis['points'] = np.tile(data_axis['points'], experiment.repeats)
 
-        # See if there are multiple partitions, and therefore metadata
-        if len(desc) > 1:
-            meta_axis = desc[1] # Metadata will always be the second axis
+        # Search for calibration axis, i.e., metadata
+        axis_names = [d['name'] for d in desc]
+        if 'calibration' in axis_names:
+            meta_axis = desc[axis_names.index('calibration')]
             # There should be metadata for each cal describing what it is
-            metadata = ['data']*len(data_axis['points']) + meta_axis['points']
-
-            # Pad the data axis with dummy equidistant x-points for the extra calibration points
-            avg_step = (data_axis['points'][-1] - data_axis['points'][0])/(len(data_axis['points'])-1)
-            points = np.append(data_axis['points'], data_axis['points'][-1] + (np.arange(len(meta_axis['points']))+1)*avg_step)
-
+            if len(desc)>1:
+                metadata = ['data']*len(data_axis['points']) + meta_axis['points']
+                # Pad the data axis with dummy equidistant x-points for the extra calibration points
+                avg_step = (data_axis['points'][-1] - data_axis['points'][0])/(len(data_axis['points'])-1)
+                points = np.append(data_axis['points'], data_axis['points'][-1] + (np.arange(len(meta_axis['points']))+1)*avg_step)
+            else:
+                metadata = meta_axis['points'] # data may consist of calibration points only
+                points = np.arange(len(metadata)) # dummy axis for plotting purposes
             # If there's only one segment we can ignore this axis
             if len(points) > 1:
                 experiment.segment_axis = DataAxis(data_axis['name'], points, unit=data_axis['unit'], metadata=metadata)


### PR DESCRIPTION
This allows taking data consisting of calibration points only, or
placing calibration points at different positions in the sequence. Slightly less restrictive then having always [data, calibrations] or [data]. But still allowing a single calibration axis found by name. 