### PR TITLE
Actually use the default plotter mode from config without overwrite

### DIFF
--- a/src/auspex/exp_factory.py
+++ b/src/auspex/exp_factory.py
@@ -152,8 +152,9 @@ class QubitExpFactory(object):
     will override some of the config values depending on the experiment being run."""
 
     @staticmethod
-    def run(meta_file=None, meas_file=None, expname=None, calibration=False, save_data=True,
-           cw_mode=False, repeats=None, single_plotter=auspex.config.single_plotter_mode):
+    def run(meta_file=None, meas_file=None, expname=None, calibration=False, \
+        save_data=True, cw_mode=False, repeats=None, \
+        single_plotter=auspex.config.single_plotter_mode):
         """This passes all of the parameters given to the *create* method
         and then runs the experiment immediately."""
 
@@ -161,9 +162,10 @@ class QubitExpFactory(object):
         spm = auspex.config.single_plotter_mode
         auspex.config.single_plotter_mode = single_plotter
 
-        exp = QubitExpFactory.create(meta_file=meta_file, meas_file=meas_file, expname=expname,
-                                     calibration=calibration, cw_mode=cw_mode, save_data=save_data,
-                                    repeats=repeats)
+        exp = QubitExpFactory.create(meta_file=meta_file, meas_file=meas_file, \
+            expname=expname, calibration=calibration, cw_mode=cw_mode, \
+            save_data=save_data, repeats=repeats, \
+            single_plotter=single_plotter)
         exp.run_sweeps()
 
         # set the plotting mode back to the default value
@@ -171,8 +173,9 @@ class QubitExpFactory(object):
         return exp
 
     @staticmethod
-    def create(meta_file=None, meas_file=None, expname=None, calibration=False, save_data=True,
-               cw_mode=False, instr_filter=None, repeats=None):
+    def create(meta_file=None, meas_file=None, expname=None, \
+        calibration=False, save_data=True, cw_mode=False, instr_filter=None, \
+        repeats=None, single_plotter=single_plotter):
         """Create the experiment, but do not run the sweeps. If *cw_mode* is specified
         the AWGs will be operated in continuous waveform mode, and will not be stopped
         and started between succesive sweep points. The *calibration* argument is used
@@ -195,6 +198,8 @@ class QubitExpFactory(object):
         experiment.cw_mode         = cw_mode
         experiment.calibration     = calibration
         experiment.repeats         = repeats
+
+        experiment.single_plotter_mode = single_plotter
 
         if meta_file:
             QubitExpFactory.load_meta_info(experiment, meta_file)

--- a/src/auspex/exp_factory.py
+++ b/src/auspex/exp_factory.py
@@ -153,18 +153,26 @@ class QubitExpFactory(object):
 
     @staticmethod
     def run(meta_file=None, meas_file=None, expname=None, calibration=False, save_data=True,
-           cw_mode=False, repeats=None, single_plotter=True):
+           cw_mode=False, repeats=None, single_plotter=auspex.config.single_plotter_mode):
         """This passes all of the parameters given to the *create* method
         and then runs the experiment immediately."""
+
+        # allow the plotter mode to be overridden
+        spm = auspex.config.single_plotter_mode
+        auspex.config.single_plotter_mode = single_plotter
+
         exp = QubitExpFactory.create(meta_file=meta_file, meas_file=meas_file, expname=expname,
                                      calibration=calibration, cw_mode=cw_mode, save_data=save_data,
-                                    repeats=repeats, single_plotter=single_plotter)
+                                    repeats=repeats)
         exp.run_sweeps()
+
+        # set the plotting mode back to the default value
+        auspex.config.single_plotter_mode = spm
         return exp
 
     @staticmethod
     def create(meta_file=None, meas_file=None, expname=None, calibration=False, save_data=True,
-               cw_mode=False, instr_filter=None, repeats=None, single_plotter=True):
+               cw_mode=False, instr_filter=None, repeats=None):
         """Create the experiment, but do not run the sweeps. If *cw_mode* is specified
         the AWGs will be operated in continuous waveform mode, and will not be stopped
         and started between succesive sweep points. The *calibration* argument is used
@@ -177,9 +185,6 @@ class QubitExpFactory(object):
 
         # Figure out which config file we should use, defaulting to the supplied argument
         settings = config.load_meas_file(meas_file)
-
-        # This is generally the behavior we want
-        auspex.config.single_plotter_mode = single_plotter
 
         # Instantiate and perform all of our setup
         experiment = QubitExperiment()

--- a/src/auspex/experiment.py
+++ b/src/auspex/experiment.py
@@ -200,6 +200,7 @@ class Experiment(metaclass=MetaExperiment):
         self.manual_plotters = [] # Plotters using neither streams nor the pipeline
         self.manual_plotter_callbacks = [] # These are called at the end of run
         self._extra_plots_to_streams = {}
+        self.single_plotter_mode = auspex.config.single_plotter_mode
 
         # Furthermore, keep references to all of the file writers.
         # If multiple writers request acces to the same filename, they
@@ -599,7 +600,7 @@ class Experiment(metaclass=MetaExperiment):
             plotter.plot_server = self.extra_plot_server
         time.sleep(0.5)
         # Kill a previous plotter if desired.
-        if auspex.config.single_plotter_mode and auspex.config.last_plotter_process:
+        if self.single_plotter_mode and auspex.config.last_plotter_process:
             pros = [auspex.config.last_plotter_process]
             if (not self.leave_plot_server_open or self.first_exp) and auspex.config.last_extra_plotter_process:
                 pros += [auspex.config.last_extra_plotter_process]

--- a/src/auspex/single_shot_fidelity.py
+++ b/src/auspex/single_shot_fidelity.py
@@ -29,7 +29,7 @@ import auspex.config
 class SingleShotFidelityExperiment(QubitExperiment):
     """Experiment to measure single-shot measurement fidelity of a qubit."""
 
-    def __init__(self, qubit_names, num_shots=10000, expname=None, meta_file=None, save_data=False, optimize=False, set_threshold = True, stream_type = 'Raw'):
+    def __init__(self, qubit_names, num_shots=10000, expname=None, meta_file=None, save_data=False, optimize=False, set_threshold = True, stream_type = 'Raw', single_plotter=auspex.config.single_plotter_mode):
         """Create a single shot fidelity measurement experiment. Assumes that there is a single shot measurement
         filter in the filter pipeline.
         Arguments:
@@ -38,7 +38,9 @@ class SingleShotFidelityExperiment(QubitExperiment):
             expname: Experiment name for data saving.
             meta_file: Meta file for defining custom single-shot fidelity experiment.
             save_data: If true, will save the raw or demodulated data.
-            optimize: if true, will set the swept parameters to their optimum values"""
+            optimize: if true, will set the swept parameters to their optimum values
+            stream_type: choose the stream for fidelity measurements.  This will typically be the Raw stream.
+            spm: single_plotter_mode take the default value from config.py unless it's overridden"""
 
         super(SingleShotFidelityExperiment, self).__init__()
         self.qubit_names = qubit_names if isinstance(qubit_names, list) else [qubit_names]
@@ -68,7 +70,7 @@ class SingleShotFidelityExperiment(QubitExperiment):
             QubitExpFactory.load_parameter_sweeps(experiment)
         self.ssf = self.find_single_shot_filter()
         self.leave_plot_server_open = True
-        auspex.config.single_plotter_mode = True
+        auspex.config.single_plotter_mode = single_plotter
 
     def run_sweeps(self):
         #For now, only update histograms if we don't have a parameter sweep.

--- a/src/auspex/single_shot_fidelity.py
+++ b/src/auspex/single_shot_fidelity.py
@@ -30,7 +30,8 @@ class SingleShotFidelityExperiment(QubitExperiment):
     """Experiment to measure single-shot measurement fidelity of a qubit."""
 
     def __init__(self, qubit_names, num_shots=10000, expname=None, meta_file=None, save_data=False, optimize=False, set_threshold = True, stream_type = 'Raw', single_plotter=auspex.config.single_plotter_mode):
-        """Create a single shot fidelity measurement experiment. Assumes that there is a single shot measurement
+        """
+        Create a single shot fidelity measurement experiment. Assumes that there is a single shot measurement
         filter in the filter pipeline.
         Arguments:
             qubit_names: Names of the qubits to be measured. (str)
@@ -40,7 +41,8 @@ class SingleShotFidelityExperiment(QubitExperiment):
             save_data: If true, will save the raw or demodulated data.
             optimize: if true, will set the swept parameters to their optimum values
             stream_type: choose the stream for fidelity measurements.  This will typically be the Raw stream.
-            spm: single_plotter_mode take the default value from config.py unless it's overridden"""
+            single_plotter: single_plotter_mode take the default value from config.py unless it's overridden
+        """
 
         super(SingleShotFidelityExperiment, self).__init__()
         self.qubit_names = qubit_names if isinstance(qubit_names, list) else [qubit_names]


### PR DESCRIPTION
Open request for comments.  Looks like everyone is just manually setting single_plotter_mode to true in the QubitExpFactory.  This is confusing dinosaurs like myself who thought the config.py settings were being respected.  Do others have strong feelings on how this should work?  Seems you could easily set a global variable if that's how you always wanted things to behave and overwrite as necessary in the run function.