### PR TITLE
Pure-python Holzworth driver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - export GIT_LFS_SKIP_SMUDGE=1
   - pip install git+https://github.com/BBN-Q/Adapt.git
   - pip install git+https://github.com/BBN-Q/QGL.git
-  - pip install tqdm pyvisa coveralls ruamel.yaml watchdog scikit-learn
+  - pip install tqdm pyvisa coveralls ruamel.yaml watchdog scikit-learn pyusb
   - export GIT_LFS_SKIP_SMUDGE=0
   - conda install -c ecpy atom;
   - export PYTHONPATH=$PYTHONPATH:$PWD/src

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ scikit-learn >= 0.18.1
 ruamel.yaml >= 0.15.18
 psutil >= 5.0.0
 pyzmq >= 16.0.0
+pyusb >= 1.0.2

--- a/setup.py
+++ b/setup.py
@@ -19,13 +19,13 @@ install_requires = [
     "psutil >= 5.0.0",
     "cffi >= 1.11.5",
     "scikit-learn >= 0.19.1",
-    "pyzmq >= 16.0.0"
+    "pyzmq >= 16.0.0",
+    "pyusb >= 1.0.2"
 ]
 
 #Use PyVISA-Py if running on Linux or MacOS
 if os.name == "posix":
     install_requires.append("PyVISA-Py >= 0.2")
-    install_requires.append("pyusb >= 1.0.2")
     install_requires.append("pyserial >= 3.4")
 
 setup(

--- a/src/auspex/instruments/holzworth.py
+++ b/src/auspex/instruments/holzworth.py
@@ -9,9 +9,115 @@
 __all__ = ['HolzworthHS9000']
 
 from .instrument import Instrument, MetaInstrument
+import usb
 from auspex.log import logger
+from auspex import config
 from unittest.mock import MagicMock
 import ctypes
+
+class HolzworthDevice(object):
+
+    TIMEOUT = 100
+
+    def __init__(self, device):
+        super(HolzworthDevice, self).__init__()
+
+        if not isinstance(device, usb.core.Device):
+            raise TypeError("Holzworth device must receive a USB device!")
+
+        self._device = device
+        self._device.reset()
+        if self._device.is_kernel_driver_active(0):
+            self._device.detach_kernel_driver(0)
+        self._device.set_configuration()
+
+        if "Holzworth" not in usb.util.get_string(self._device, self._device.iManufacturer):
+            raise ValueError("Not a Holzworth!")
+
+        self._e_in = self._device[0][(0,0)][0]
+        self._e_out = self._device[0][(0,0)][1]
+
+        self.channels = self.query(":ATTACH?").split(":")[1:-1]
+        if not self.channels:
+            raise ValueError("Holzworth has no channels!")
+
+        self.serial = self.query(":{}:IDN?".format(self.channels[0])).split(',')[-1]
+
+    def __del__(self):
+        if self._device is not None:
+            usb.util.dispose_resources(self._device)
+        super(HolzworthDevice, self).__del__()
+
+    def write(self, command):
+        try:
+            wlen = self._e_out.write(command.encode(), timeout=self.TIMEOUT)
+            assert wlen == len(command.encode())
+        except usb.core.USBError:
+            logger.error("Command {} to Holzworth {} timed out!".format(command, self.serial))
+
+    def read(self, nbytes=64):
+        try:
+            data = elf._e_in.read(nbytes, timeout=self.TIMEOUT)
+        except usb.core.USBError:
+            logger.error("Read from Holzworth {} timed out!".format(command, self.serial))
+        #Strip NULLs from reply and decode
+        return bytes(data).partition(b'\0')[0].decode()
+
+    def query(self, command, nbytes=64):
+        self.write(command)
+        response = self.read(nbytes=nbytes)
+        if response == "Invalid Command":
+            logger.error("Invalid command {} to Holzworth {}.".format(command, self.serial))
+        return response
+
+class HolzworthPythonDriver(object):
+
+    HOLZWORTH_VENDOR_ID = 0x1bb3
+    HOLZWORTH_PRODUCT_ID = 0x1001
+
+    def __init__(self):
+        super(HolzworthPythonDriver, self).__init__()
+
+        devices = {}
+        for dev in usb.core.find(idVendor = self.HOLZWORTH_VENDOR_ID,
+                             idProduct = self.HOLZWORTH_PRODUCT_ID,
+                             find_all=True):
+            holz = HolzworthDevice(dev)
+            devices[holz.serial] = holz
+
+        if not devices:
+            raise IOError("No Holzworth devices found.")
+
+    def enumerate(self):
+        return self.devices.keys()
+
+    def ch_check(serial, channel):
+        if serial not in self.devices.keys():
+            ValueError("Holzworth {} not connected!".format(serial))
+        if channel not in self.devices[serial]:
+            ValueError("Holzworth {} does not have channel {}".format(serial, channel))
+
+    def read(self, serial):
+        return self.devices[serial].read()
+
+    def write(self, serial, command):
+        self.devices[serial].write(command)
+
+    def query(self, serial, command):
+        self.devices[serial].query(command)
+
+if config.auspex_dummy_mode:
+    fake_holzworth = True
+else:
+    try:
+        holzworth_driver = HolzworthPythonDriver()
+        fake_holzworth = False
+    except Exception as e:
+        logger.warning("Could not connect to Holzworths: {}".format(e))
+        if str(e) == "No backend available":
+            logger.warning("You may not have the libusb backend: please install it!")
+        holzworth_driver = MagicMock()
+        fake_holzworth = True
 
 class MakeSettersGetters(MetaInstrument):
     def __init__(self, name, bases, dct):
@@ -30,27 +136,10 @@ class HolzworthHS9000(Instrument, metaclass=MakeSettersGetters):
     def __init__(self, resource_name=None, name="Unlabeled Holzworth HS9000"):
         self.name = name
         self.resource_name = resource_name
-        try:
-            self._lib = ctypes.CDLL("HolzworthMulti.dll")
-            self.fake_holz = False
-        except:
-            logger.warning("Could not find the Holzworth driver.")
-            self._lib = MagicMock()
-            self.fake_holz = True
-
-        self._lib.usbCommWrite.restype = ctypes.c_char_p
-        self._lib.openDevice.restype = ctypes.c_int
 
     @classmethod
     def enumerate(cls):
-        try:
-            lib = ctypes.CDLL("HolzworthMulti.dll")
-        except:
-            logger.error("Could not find the Holzworth driver.")
-            return
-        lib.getAttachedDevices.restype = ctypes.c_char_p
-        devices = lib.getAttachedDevices()
-        return devices.decode('ascii').split(',')
+        return holzworth_driver.enumerate()
 
     def connect(self, resource_name=None):
         if resource_name is not None:
@@ -58,9 +147,8 @@ class HolzworthHS9000(Instrument, metaclass=MakeSettersGetters):
         # parse resource_name: expecting something like "HS9004A-009-1"
         model, serial, self.chan = self.resource_name.split("-")
         self.serial = model + '-' + serial
-        success = self._lib.openDevice(self.serial.encode('ascii'))
-        if success != 0:
-            logger.debug("Could not open Holzworth at address: {}, might already be open on another channel.".format(self.serial))
+        holzworth_driver.ch_check(self.serial, self.chan)
+
         # read frequency and power ranges
         self.fmin = float((self.ch_query(":FREQ:MIN?")).split()[0]) * 1e6 #Hz
         self.fmax = float((self.ch_query(":FREQ:MAX?")).split()[0]) * 1e6 #Hz
@@ -68,13 +156,13 @@ class HolzworthHS9000(Instrument, metaclass=MakeSettersGetters):
         self.pmax = float((self.ch_query(":PWR:MAX?")).split()[0]) #dBm
 
     def ref_query(self, scpi_string):
-        serial = self.serial + '-R'
-        return self._lib.usbCommWrite(serial.encode('ascii'), scpi_string.encode('ascii')).decode('ascii')
+        serial = self.serial
+        return holzworth_driver.query(self.serial, ":REF{}".format(scpi_string))
 
     def ch_query(self, scpi_string):
         chan_string = ":CH{}".format(self.chan)
         scpi_string = chan_string + scpi_string
-        return self._lib.usbCommWrite(self.resource_name.encode('ascii'), scpi_string.encode('ascii')).decode('ascii')
+        return holzworth_driver.query(self.serial, scpi_string)
 
     @property
     def frequency(self):
@@ -82,13 +170,12 @@ class HolzworthHS9000(Instrument, metaclass=MakeSettersGetters):
         return float(v.split()[0]) * 1e6
     @frequency.setter
     def frequency(self, value):
-        if not self.fake_holz:
-            if self.fmin <= value <= self.fmax:
-                # WARNING!!! The Holzworth might blow up if you ask for >12 digits of precision here
-                self.ch_query(":FREQ:{:.12g} Hz".format(value))
-            else:
-                err_msg = "The value {} GHz is outside of the allowable range {}-{} GHz specified for instrument '{}'.".format(value*1e-9, self.fmin*1e-9, self.fmax*1e-9, self.name)
-                raise ValueError(err_msg)
+        if self.fmin <= value <= self.fmax:
+            # WARNING!!! The Holzworth might blow up if you ask for >12 digits of precision here
+            self.ch_query(":FREQ:{:.12g} Hz".format(value))
+        else:
+            err_msg = "The value {} GHz is outside of the allowable range {}-{} GHz specified for instrument '{}'.".format(value*1e-9, self.fmin*1e-9, self.fmax*1e-9, self.name)
+            raise ValueError(err_msg)
 
     @property
     def power(self):
@@ -96,12 +183,11 @@ class HolzworthHS9000(Instrument, metaclass=MakeSettersGetters):
         return float(v.split()[0])
     @power.setter
     def power(self, value):
-        if not self.fake_holz:
-            if self.pmin <= value <= self.pmax:
-                self.ch_query(":PWR:{} dBm".format(value))
-            else:
-                err_msg = "The value {} dBm is outside of the allowable range {}-{} dBm specified for instrument '{}'.".format(value, self.pmin, self.pmax, self.name)
-                raise ValueError(err_msg)
+        if self.pmin <= value <= self.pmax:
+            self.ch_query(":PWR:{} dBm".format(value))
+        else:
+            err_msg = "The value {} dBm is outside of the allowable range {}-{} dBm specified for instrument '{}'.".format(value, self.pmin, self.pmax, self.name)
+            raise ValueError(err_msg)
 
     @property
     def phase(self):
@@ -127,18 +213,15 @@ class HolzworthHS9000(Instrument, metaclass=MakeSettersGetters):
 
     @property
     def reference(self):
-        v = self.ref_query(":REF:STATUS?")
+        v = self.ref_query(":STATUS?")
         return v
     @reference.setter
     def reference(self, value):
         ref_opts = ["INT", "10MHz", "100MHz"]
         if value in ref_opts:
             if value == "INT":
-                self.ref_query(":REF:INT:100MHz")
+                self.ref_query(":INT:100MHz")
             else:
-                self.ref_query(":REF:EXT:{}".format(value))
+                self.ref_query(":EXT:{}".format(value))
         else:
             raise ValueError("Reference must be one of {}.".format(ref_opts))
-
-    def __del__(self):
-        self._lib.close_all()

--- a/src/auspex/instruments/holzworth.py
+++ b/src/auspex/instruments/holzworth.py
@@ -286,7 +286,7 @@ class HolzworthHS9000DLL(HolzworthInstrument, metaclass=MakeSettersGetters):
         return self._lib.usbCommWrite(self.resource_name.encode('ascii'), scpi_string.encode('ascii')).decode('ascii')
 
 #create class based on OS...
-class HolzworthHS9000(object):
+class HolzworthHS9000(Instrument):
     def __new__(cls, *args, **kwargs):
         if os.name == "posix":
             obj = object.__new__(HolzworthHS9000Py, *args, **kwargs)

--- a/src/auspex/instruments/holzworth.py
+++ b/src/auspex/instruments/holzworth.py
@@ -138,10 +138,16 @@ class HolzworthInstrument(Instrument, metaclass=MakeSettersGetters):
 
     def get_info(self):
         # read frequency and power ranges
-        self.fmin = float((self.ch_query(":FREQ:MIN?")).split()[0]) * 1e6 #Hz
-        self.fmax = float((self.ch_query(":FREQ:MAX?")).split()[0]) * 1e6 #Hz
-        self.pmin = float((self.ch_query(":PWR:MIN?")).split()[0]) #dBm
-        self.pmax = float((self.ch_query(":PWR:MAX?")).split()[0]) #dBm
+        if fake_holzworth:
+            self.fmin = 10e3
+            self.fmax = 20e9
+            self.pmin = -80.
+            self.pmax = 16.
+        else:
+            self.fmin = float((self.ch_query(":FREQ:MIN?")).split()[0]) * 1e6 #Hz
+            self.fmax = float((self.ch_query(":FREQ:MAX?")).split()[0]) * 1e6 #Hz
+            self.pmin = float((self.ch_query(":PWR:MIN?")).split()[0]) #dBm
+            self.pmax = float((self.ch_query(":PWR:MAX?")).split()[0]) #dBm
 
     @property
     def frequency(self):

--- a/src/auspex/instruments/holzworth.py
+++ b/src/auspex/instruments/holzworth.py
@@ -85,7 +85,7 @@ class HolzworthPythonDriver(object):
                              idProduct = self.HOLZWORTH_PRODUCT_ID,
                              find_all=True):
             holz = HolzworthDevice(dev)
-            logger.info("Found Holzworth {} with channels {}".format(holz.serial, holz.channels))
+            logger.debug("Found Holzworth {} with channels {}".format(holz.serial, holz.channels))
             self.devices[holz.serial] = holz
 
         if not self.devices:


### PR DESCRIPTION
Pure-python Holzworth driver using `pyusb` for the Holzworth synthesizers. In principle should work for windows as well if you can convince Windows to use `libusb`, but for now includes a fallback to the Holzworth-supplied DLL.  