### PR TITLE
Fix/mp woes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
   - pip install git+https://github.com/BBN-Q/Adapt.git
   - pip install git+https://github.com/BBN-Q/QGL.git@sqlalchemy
   - pip install git+https://github.com/spatialaudio/nbsphinx.git@master
-  - pip install pyvisa coveralls scikit-learn pyusb future python-usbtmc
+  - pip install pyvisa coveralls scikit-learn pyusb future python-usbtmc setproctitle
   - export GIT_LFS_SKIP_SMUDGE=0
   - export PYTHONPATH=$PYTHONPATH:$PWD/src
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,5 @@ git+https://github.com/bbn-q/bbndb.git
 pyusb >= 1.0.2
 ipykernel>=5.0.0
 ipywidgets>=7.0.0
+setproctitle
 git+https://github.com/spatialaudio/nbsphinx.git@master

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ install_requires = [
     "python-usbtmc >= 0.8",
     "ipykernel>=5.0.0",
     "ipywidgets>=7.0.0",
-    "sqlalchemy >= 1.2.15"
+    "sqlalchemy >= 1.2.15",
+    "setproctitle"
 ]
 
 #Use PyVISA-Py if running on Linux or MacOS

--- a/src/auspex/experiment.py
+++ b/src/auspex/experiment.py
@@ -306,7 +306,7 @@ class Experiment(metaclass=MetaExperiment):
             # values of the SweepAxes (no DataAxes).
             sweep_values, axis_names = self.sweeper.update()
 
-            if hasattr(self, 'progressbars'):
+            if hasattr(self, 'progressbars') and self.progressbars:
                 for axis in self.sweeper.axes:
                     if axis.done:
                         self.progressbars[axis].value = axis.num_points()
@@ -568,7 +568,7 @@ class Experiment(metaclass=MetaExperiment):
                 self.perf_thread.join()
 
         except Exception as e:
-            logger.warning("Encountered error in run sweeps after initializing experiments")
+            logger.warning(f"Encountered error '{e}' in run sweeps after initializing experiments")
             raise e
         except KeyboardInterrupt as e:
             print("Caught KeyboardInterrupt, terminating.")

--- a/src/auspex/experiment.py
+++ b/src/auspex/experiment.py
@@ -589,11 +589,15 @@ class Experiment(metaclass=MetaExperiment):
         # This includes stopping the flow of data, and must be done before terminating nodes
         self.shutdown_instruments()
 
-        for n in self.other_nodes:
-            n.exit.set()
-            n.join(0.1)
-            if n.is_alive():
-                logger.info(f"Terminating {str(n)} aggressively")
+        try:
+            while True:
+                time.sleep(2)
+                if any([n.is_alive() for n in self.other_nodes]):
+                    logger.warning("Filter pipeline has not finished processing yet. Use keyboard interrupt to terminate.")
+                else:
+                    break
+        except KeyboardInterrupt as e:
+            for n in self.other_nodes:
                 n.terminate()
 
         if not self.keep_instruments_connected:

--- a/src/auspex/experiment.py
+++ b/src/auspex/experiment.py
@@ -606,7 +606,7 @@ class Experiment(metaclass=MetaExperiment):
             self.disconnect_instruments()
 
         for n in self.other_nodes:
-            del n
+            n.done.set()
 
         import gc
         gc.collect()

--- a/src/auspex/filters/filter.py
+++ b/src/auspex/filters/filter.py
@@ -167,7 +167,6 @@ class Filter(Process, metaclass=MetaFilter):
         else:
             self.execute_on_run()
             self.main()
-        logger.debug(f"{self} done")
         self.done.set()
 
     def execute_on_run(self):
@@ -256,7 +255,6 @@ class Filter(Process, metaclass=MetaFilter):
                     break
 
             # When we've finished, either prematurely or as expected
-            logger.debug(f"{self} leaving main loop")
             self.on_done()
 
         except Exception as e:

--- a/src/auspex/filters/filter.py
+++ b/src/auspex/filters/filter.py
@@ -21,6 +21,7 @@ else:
     from multiprocessing import Event
     from multiprocessing import Queue
 
+from setproctitle import setproctitle
 import cProfile
 import itertools
 import time, datetime
@@ -146,8 +147,17 @@ class Filter(Process, metaclass=MetaFilter):
     def shutdown(self):
         self.exit.set()
 
+    def _parent_process_running(self):
+        try:
+            os.kill(os.getppid(), 0)
+        except OSError:
+            return False
+        else:
+            return True
+
     def run(self):
         self.p = psutil.Process(os.getpid())
+        logger.info(f"{self} launched with pid {os.getpid()}. ppid {os.getppid()}")
         if auspex.config.profile:
             if not self.filter_name:
                 name = "Unlabeled"
@@ -178,90 +188,102 @@ class Filter(Process, metaclass=MetaFilter):
         """
         Generic run method which waits on a single stream and calls `process_data` on any new_data
         """
-        logger.debug('Running "%s" run loop', self.filter_name)
-        # self.finished_processing.clear()
-        input_stream = getattr(self, self._input_connectors[0]).input_streams[0]
-        desc = input_stream.descriptor
+        try:
 
-        stream_done = False
-        stream_points = 0
+            logger.debug('Running "%s" run loop', self.filter_name)
+            setproctitle('python auspex: '+str(self))
+            # self.finished_processing.clear()
+            input_stream = getattr(self, self._input_connectors[0]).input_streams[0]
+            desc = input_stream.descriptor
 
-        while not self.exit.is_set():# and not self.finished_processing.is_set():
-            # Try to pull all messages in the queue. queue.empty() is not reliable, so we
-            # ask for forgiveness rather than permission.
-            messages = []
+            stream_done = False
+            stream_points = 0
 
-            while not self.exit.is_set():
-                try:
-                    messages.append(input_stream.queue.get(False))
-                except queue.Empty as e:
-                    time.sleep(0.002)
+            while not self.exit.is_set():# and not self.finished_processing.is_set():
+                # Try to pull all messages in the queue. queue.empty() is not reliable, so we
+                # ask for forgiveness rather than permission.
+                messages = []
+
+                # Check to see if the parent process still exists:
+                if not self._parent_process_running():
+                    logger.warning(f"{self} with pid {os.getpid()} could not find parent with pid {os.getppid()}. Assuming something has gone wrong. Exiting.")
                     break
 
-            self.push_resource_usage()
+                while not self.exit.is_set():
+                    try:
+                        messages.append(input_stream.queue.get(False))
+                    except queue.Empty as e:
+                        time.sleep(0.002)
+                        break
 
-            for message in messages:
-                message_type = message['type']
-                message_data = message['data']
+                self.push_resource_usage()
 
-                if message['type'] == 'event':
-                    logger.debug('%s "%s" received event "%s"', self.__class__.__name__, self.filter_name, message_data)
+                for message in messages:
+                    message_type = message['type']
+                    message_data = message['data']
 
-                    # Propagate along the graph
-                    self.push_to_all(message)
+                    if message['type'] == 'event':
+                        logger.debug('%s "%s" received event "%s"', self.__class__.__name__, self.filter_name, message_data)
 
-                    # Check to see if we're done
-                    if message['event_type'] == 'done':
-                        logger.debug(f"{self} received done message!")
-                        stream_done = True
-                    elif message['event_type'] == 'refined':
-                        self.refine(message_data)
-                        continue
-                    elif message['event_type'] == 'new_tuples':
-                        self.process_new_tuples(input_stream.descriptor, message_data)
-                        # break
+                        # Propagate along the graph
+                        self.push_to_all(message)
 
-                elif message['type'] == 'data':
-                    if not hasattr(message_data, 'size'):
-                        message_data = np.array([message_data])
-                    logger.debug('%s "%s" received %d points.', self.__class__.__name__, self.filter_name, message_data.size)
-                    logger.debug("Now has %d of %d points.", input_stream.points_taken.value, input_stream.num_points())
-                    stream_points += len(message_data.flatten())
-                    self.process_data(message_data.flatten())
-                    self.processed += message_data.nbytes
+                        # Check to see if we're done
+                        if message['event_type'] == 'done':
+                            logger.debug(f"{self} received done message!")
+                            stream_done = True
+                        elif message['event_type'] == 'refined':
+                            self.refine(message_data)
+                            continue
+                        elif message['event_type'] == 'new_tuples':
+                            self.process_new_tuples(input_stream.descriptor, message_data)
+                            # break
 
-                elif message['type'] == 'data_direct':
-                    self.processed += message_data.nbytes
-                    self.process_direct(message_data)
+                    elif message['type'] == 'data':
+                        if not hasattr(message_data, 'size'):
+                            message_data = np.array([message_data])
+                        logger.debug('%s "%s" received %d points.', self.__class__.__name__, self.filter_name, message_data.size)
+                        logger.debug("Now has %d of %d points.", input_stream.points_taken.value, input_stream.num_points())
+                        stream_points += len(message_data.flatten())
+                        self.process_data(message_data.flatten())
+                        self.processed += message_data.nbytes
 
-                # if stream_points == input_stream.num_points():
-                #     self.finished_processing.set()
-                #     break
+                    elif message['type'] == 'data_direct':
+                        self.processed += message_data.nbytes
+                        self.process_direct(message_data)
 
-            if stream_done:
-                # outputs = self.output_connectors.values()
+                    # if stream_points == input_stream.num_points():
+                    #     self.finished_processing.set()
+                    #     break
 
-                # if outputs:
-                #     output_status = [v.done() for v in outputs]
-                #     print('x dones: %s' % str(output_status))
+                if stream_done:
+                    # outputs = self.output_connectors.values()
 
-                #     if not np.all(output_status):
-                #         print('------------------->>>>>>>>> NOT ALL DONE YET')
+                    # if outputs:
+                    #     output_status = [v.done() for v in outputs]
+                    #     print('x dones: %s' % str(output_status))
 
-                self.done.set()
-                break
-            # if desc.is_adaptive():
-            #     if stream_done and np.all([len(desc.visited_tuples) == points_taken[s] for s in streams]):
-            #         # self.finished_processing.set()
-            #         break
-            # else:
-            #     if stream_done and np.all([v.done() for v in self.input_connectors.values()]):
-            #         self.finished_processing.set()
-            #         break
+                    #     if not np.all(output_status):
+                    #         print('------------------->>>>>>>>> NOT ALL DONE YET')
 
-        # When we've finished, either prematurely or as expected
-        # print(self.filter_name, "leaving main loop")
-        self.on_done()
+                    self.done.set()
+                    break
+                # if desc.is_adaptive():
+                #     if stream_done and np.all([len(desc.visited_tuples) == points_taken[s] for s in streams]):
+                #         # self.finished_processing.set()
+                #         break
+                # else:
+                #     if stream_done and np.all([v.done() for v in self.input_connectors.values()]):
+                #         self.finished_processing.set()
+                #         break
+
+            # When we've finished, either prematurely or as expected
+            logger.info(f"{self} leaving main loop")
+            self.on_done()
+
+        except Exception as e:
+            logger.warning(f"Filter {self} raised exception {e}. Bailing.")
+
 
     def process_data(self, data):
         """Process data coming through the filter pipeline"""

--- a/src/auspex/filters/filter.py
+++ b/src/auspex/filters/filter.py
@@ -191,8 +191,7 @@ class Filter(Process, metaclass=MetaFilter):
         try:
 
             logger.debug('Running "%s" run loop', self.filter_name)
-            setproctitle('python auspex: '+str(self))
-            # self.finished_processing.clear()
+            setproctitle(f"python auspex filter: {self}")
             input_stream = getattr(self, self._input_connectors[0]).input_streams[0]
             desc = input_stream.descriptor
 
@@ -252,33 +251,12 @@ class Filter(Process, metaclass=MetaFilter):
                         self.processed += message_data.nbytes
                         self.process_direct(message_data)
 
-                    # if stream_points == input_stream.num_points():
-                    #     self.finished_processing.set()
-                    #     break
-
                 if stream_done:
-                    # outputs = self.output_connectors.values()
-
-                    # if outputs:
-                    #     output_status = [v.done() for v in outputs]
-                    #     print('x dones: %s' % str(output_status))
-
-                    #     if not np.all(output_status):
-                    #         print('------------------->>>>>>>>> NOT ALL DONE YET')
-
                     self.done.set()
                     break
-                # if desc.is_adaptive():
-                #     if stream_done and np.all([len(desc.visited_tuples) == points_taken[s] for s in streams]):
-                #         # self.finished_processing.set()
-                #         break
-                # else:
-                #     if stream_done and np.all([v.done() for v in self.input_connectors.values()]):
-                #         self.finished_processing.set()
-                #         break
 
             # When we've finished, either prematurely or as expected
-            logger.info(f"{self} leaving main loop")
+            logger.debug(f"{self} leaving main loop")
             self.on_done()
 
         except Exception as e:

--- a/src/auspex/filters/filter.py
+++ b/src/auspex/filters/filter.py
@@ -157,7 +157,7 @@ class Filter(Process, metaclass=MetaFilter):
 
     def run(self):
         self.p = psutil.Process(os.getpid())
-        logger.info(f"{self} launched with pid {os.getpid()}. ppid {os.getppid()}")
+        logger.debug(f"{self} launched with pid {os.getpid()}. ppid {os.getppid()}")
         if auspex.config.profile:
             if not self.filter_name:
                 name = "Unlabeled"

--- a/src/auspex/instruments/X6.py
+++ b/src/auspex/instruments/X6.py
@@ -145,7 +145,7 @@ class X6(Instrument):
         self._lib.connect(int(self.resource_name))
 
     def disconnect(self):
-        if self._lib.device_id and self._lib.get_is_running():
+        if hasattr(self, '_lib') and self._lib.device_id and self._lib.get_is_running():
             self._lib.stop()
         for sock in self._chan_to_rsocket.values():
             sock.close()

--- a/src/auspex/instruments/X6.py
+++ b/src/auspex/instruments/X6.py
@@ -264,7 +264,7 @@ class X6(Instrument):
 
         return total
 
-    def receive_data(self, channel, oc, exit, ready):
+    def receive_data(self, channel, oc, exit, ready, run):
         try:
             sock = self._chan_to_rsocket[channel]
             sock.settimeout(2)
@@ -277,6 +277,7 @@ class X6(Instrument):
                 # push data from a socket into an OutputConnector (oc)
                 # wire format is just: [size, buffer...]
                 # TODO receive 4 or 8 bytes depending on sizeof(size_t)
+                run.wait() # Block until we are running again
                 try:
                     msg = sock.recv(8)
                     self.last_timestamp.value = datetime.datetime.now().timestamp()
@@ -313,7 +314,7 @@ class X6(Instrument):
     def get_buffer_for_channel(self, channel):
         return self._lib.transfer_stream(*channel.channel)
 
-    def wait_for_acquisition(self, timeout=15, ocs=None, progressbars=None):
+    def wait_for_acquisition(self, dig_run, timeout=15, ocs=None, progressbars=None):
 
         if self.gen_fake_data:
             total_spewed = 0
@@ -358,6 +359,8 @@ class X6(Instrument):
 
         else:
             while not self.done():
+                if not dig_run.is_set():
+                    self.last_timestamp.value = datetime.datetime.now().timestamp()
                 if (datetime.datetime.now().timestamp() - self.last_timestamp.value) > timeout:
                     logger.error("Digitizer %s timed out.", self.name)
                     break

--- a/src/auspex/instruments/X6.py
+++ b/src/auspex/instruments/X6.py
@@ -272,7 +272,7 @@ class X6(Instrument):
             total = 0
             ready.value += 1
 
-            logger.info(f"{self} receiver launched with pid {os.getpid()}. ppid {os.getppid()}")
+            logger.debug(f"{self} receiver launched with pid {os.getpid()}. ppid {os.getppid()}")
             while not exit.is_set():
                 # push data from a socket into an OutputConnector (oc)
                 # wire format is just: [size, buffer...]

--- a/src/auspex/instruments/X6.py
+++ b/src/auspex/instruments/X6.py
@@ -145,7 +145,7 @@ class X6(Instrument):
         self._lib.connect(int(self.resource_name))
 
     def disconnect(self):
-        if self._lib.get_is_running():
+        if self._lib.device_id and self._lib.get_is_running():
             self._lib.stop()
         for sock in self._chan_to_rsocket.values():
             sock.close()

--- a/src/auspex/qubit/qubit_exp.py
+++ b/src/auspex/qubit/qubit_exp.py
@@ -496,6 +496,15 @@ class QubitExperiment(Experiment):
     def shutdown_instruments(self):
         # remove socket listeners
         logger.debug("Shutting down instruments")
+        
+        for awg in self.awgs:
+            awg.stop()
+        for dig in self.digitizers:
+            dig.stop()
+        for gen_proxy in self.generators:
+            gen_proxy.instr.output = False
+        for instr in self.instruments:
+            instr.disconnect()
         for listener, exit in self.dig_listeners.items():
             exit.set()
             listener.join(2)
@@ -503,13 +512,7 @@ class QubitExperiment(Experiment):
                 logger.info(f"Terminating listener {listener} aggressively")
                 listener.terminate()
             del listener
-        if self.cw_mode:
-            for awg in self.awgs:
-                awg.stop()
-        for gen_proxy in self.generators:
-            gen_proxy.instr.output = False
-        for instr in self.instruments:
-            instr.disconnect()
+        
         import gc
         gc.collect()
 

--- a/src/auspex/qubit/qubit_exp.py
+++ b/src/auspex/qubit/qubit_exp.py
@@ -18,6 +18,7 @@ else:
 
 from . import pipeline
 import time
+import datetime
 import json
 
 stream_hierarchy = [
@@ -408,11 +409,13 @@ class QubitExperiment(Experiment):
         # Start socket listening processes, store as keys in a dictionary with exit commands as values
         self.dig_listeners = {}
         ready = Value('i', 0)
+        self.dig_run  = Event()
+        self.dig_exit = Event()
         for chan, dig in self.chan_to_dig.items():
             socket = dig.get_socket(chan)
             oc = self.chan_to_oc[chan]
-            exit = Event()
-            self.dig_listeners[Process(target=dig.receive_data, args=(chan, oc, exit, ready))] = exit
+            p = Process(target=dig.receive_data, args=(chan, oc, self.dig_exit, ready, self.dig_run))
+            self.dig_listeners[p] = self.dig_exit
         assert None not in self.dig_listeners.keys()
         for listener in self.dig_listeners.keys():
             listener.start()
@@ -505,8 +508,8 @@ class QubitExperiment(Experiment):
             gen_proxy.instr.output = False
         for instr in self.instruments:
             instr.disconnect()
-        for listener, exit in self.dig_listeners.items():
-            exit.set()
+        self.dig_exit.set()
+        for listener in self.dig_listeners:
             listener.join(2)
             if listener.is_alive():
                 logger.info(f"Terminating listener {listener} aggressively")
@@ -546,6 +549,10 @@ class QubitExperiment(Experiment):
         # Begin acquisition before enabling the AWGs
         for dig in self.digitizers:
             dig.acquire()
+            dig.last_timestamp.value = datetime.datetime.now().timestamp()
+
+        # Set flag to enable acquisition process
+        self.dig_run.set()
 
         # Start the AWGs
         if not self.cw_mode:
@@ -553,13 +560,16 @@ class QubitExperiment(Experiment):
                 awg.run()
 
         # Wait for all of the acquisitions to complete
-        timeout = 20
+        timeout = 2
         for dig in self.digitizers:
-            dig.wait_for_acquisition(timeout, ocs=list(self.chan_to_oc.values()), progressbars=self.progressbars)
+            dig.wait_for_acquisition(self.dig_run, timeout=timeout, ocs=list(self.chan_to_oc.values()), progressbars=self.progressbars)
 
         # Bring everything to a stop
         for dig in self.digitizers:
             dig.stop()
+
+        # Pause the receiver processes so they don't time out
+        self.dig_run.clear()
 
         # Stop the AWGs
         if not self.cw_mode:

--- a/test/test_alazar.py
+++ b/test/test_alazar.py
@@ -26,7 +26,7 @@ class AlazarTestCase(unittest.TestCase):
     def basic(self, delay=1.0, averages=10, segments=20, record=1024):
         oc   = Queue()
         exit = Event()
-
+        run  = Event()
         alz  = AlazarATS9870(resource_name="1")
         ch   = AlazarChannel()
         ch.phys_channel = 1
@@ -75,12 +75,13 @@ class AlazarTestCase(unittest.TestCase):
                 self.points_taken.value += data.size
         oc = OC()
         ready = Value('i', 0)
-        proc = Process(target=alz.receive_data, args=(ch, oc, exit, ready))
+        proc = Process(target=alz.receive_data, args=(ch, oc, exit, ready, run))
         proc.start()
         while ready.value < 1:
             time.sleep(delay)
 
-        alz.wait_for_acquisition(2.0, [oc])
+        run.set()
+        alz.wait_for_acquisition(run, timeout=5, ocs=[oc])
 
         exit.set()
         time.sleep(1)


### PR DESCRIPTION
Fix shutdown ordering (instruments before filters) to prevent non-empty queues and can prevent successful joins. Add process titles for filters so you can track usage using system activity monitors. Much better keyboard interrupt handling. 