### PR TITLE
Fix X6 channel notation in examples 1 and 2

### DIFF
--- a/doc/examples/Example-Q1.ipynb
+++ b/doc/examples/Example-Q1.ipynb
@@ -33,7 +33,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Defaulting to temporary directory for AWG sequence file outputs.\n"
+      "AWG_DIR environment variable not defined. Unless otherwise specified, using temporary directory for AWG sequence file outputs.\n"
      ]
     }
    ],
@@ -52,7 +52,15 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating engine...\n"
+     ]
+    }
+   ],
    "source": [
     "cl = ChannelLibrary(db_resource_name=\":memory:\")"
    ]
@@ -126,7 +134,7 @@
     "# Qubit q1 is controlled by AWG aps2_1, and uses microwave source h1\n",
     "cl.set_control(q1, aps2_1, generator=h1)\n",
     "# Qubit q1 is measured by AWG aps2_2 and digitizer dig_1, and uses microwave source h2\n",
-    "cl.set_measure(q1, aps2_2, dig_1[\"raw-1-1\"], generator=h2)\n",
+    "cl.set_measure(q1, aps2_2, dig_1.ch(1), generator=h2)\n",
     "# The AWG aps2_1 is the master AWG, and distributes a synchronization trigger on its second marker channel\n",
     "cl.set_master(aps2_1, aps2_1.ch(\"m2\"))"
    ]
@@ -178,7 +186,7 @@
     {
      "data": {
       "text/html": [
-       "<table><tr><th>id</th><th>Year</th><th>Date</th><th>Time</th><th>Name</th></tr><tr><tr><td>1</td><td>2019</td><td>Mar. 13</td><td>12:26:47 PM</td><td>working</td></tr></tr></table>"
+       "<table><tr><th>id</th><th>Year</th><th>Date</th><th>Time</th><th>Name</th></tr><tr><tr><td>1</td><td>2019</td><td>Apr. 18</td><td>11:24:26 AM</td><td>working</td></tr></tr></table>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -208,7 +216,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "A database item with the name q1 already exists. Returning this existing item instead.\n"
+      "A database item with the name q1 already exists. Updating parameters of this existing item instead.\n"
      ]
     }
    ],
@@ -231,7 +239,7 @@
     }
    ],
    "source": [
-    "cl.set_measure(q1, aps2_2, dig_1[\"demodulated-1-1\"], generator=h2)"
+    "cl.set_measure(q1, aps2_2, dig_1.ch(1), generator=h2)"
    ]
   },
   {
@@ -266,7 +274,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "647e6121c6fd4c989dfa117a1154aee0",
+       "model_id": "baa63338814240aca5c9a27aed2a4427",
        "version_major": 2,
        "version_minor": 0
       },
@@ -318,7 +326,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.6.8"
   },
   "toc": {
    "base_numbering": 1,

--- a/doc/examples/Example-Q2.ipynb
+++ b/doc/examples/Example-Q2.ipynb
@@ -26,14 +26,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Defaulting to temporary directory for AWG sequence file outputs.\n"
+      "A database item with the name q1 already exists. Updating parameters of this existing item instead.\n",
+      "A database item with the name BBNAPS1 already exists. Updating parameters of this existing item instead.\n",
+      "A database item with the name BBNAPS2 already exists. Updating parameters of this existing item instead.\n",
+      "A database item with the name X6_1 already exists. Updating parameters of this existing item instead.\n",
+      "A database item with the name Holz1 already exists. Updating parameters of this existing item instead.\n",
+      "A database item with the name Holz2 already exists. Updating parameters of this existing item instead.\n"
      ]
     }
    ],
@@ -48,7 +53,7 @@
     "h1 = cl.new_source(\"Holz1\", \"HolzworthHS9000\", \"HS9004A-009-1\", power=-30)\n",
     "h2 = cl.new_source(\"Holz2\", \"HolzworthHS9000\", \"HS9004A-009-2\", power=-30) \n",
     "cl.set_control(q1, aps2_1, generator=h1)\n",
-    "cl.set_measure(q1, aps2_2, dig_1[\"raw-1-1\"], generator=h2)\n",
+    "cl.set_measure(q1, aps2_2, dig_1.ch(1), generator=h2)\n",
     "cl.set_master(aps2_1, aps2_1.ch(\"m2\"))\n",
     "cl[\"q1\"].measure_chan.frequency = 0e6\n",
     "cl.commit()"
@@ -63,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -79,7 +84,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -97,13 +102,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<table><tr><th>id</th><th>Year</th><th>Date</th><th>Time</th><th>Name</th></tr><tr><tr><td>1</td><td>2019</td><td>Mar. 13</td><td>12:27:56 PM</td><td>working</td></tr><tr><td>2</td><td>2019</td><td>Mar. 13</td><td>12:27:56 PM</td><td>NoSidebanding</td></tr><tr><td>3</td><td>2019</td><td>Mar. 13</td><td>12:27:57 PM</td><td>50MHz-Sidebanding</td></tr><tr><td>4</td><td>2019</td><td>Mar. 13</td><td>12:27:57 PM</td><td>50MHz-Sidebanding</td></tr></tr></table>"
+       "<table><tr><th>id</th><th>Year</th><th>Date</th><th>Time</th><th>Name</th></tr><tr><tr><td>1</td><td>2019</td><td>Apr. 18</td><td>11:25:20 AM</td><td>working</td></tr><tr><td>2</td><td>2019</td><td>Apr. 18</td><td>11:25:37 AM</td><td>NoSidebanding</td></tr><tr><td>3</td><td>2019</td><td>Apr. 18</td><td>11:25:38 AM</td><td>50MHz-Sidebanding</td></tr><tr><td>4</td><td>2019</td><td>Apr. 18</td><td>11:25:39 AM</td><td>50MHz-Sidebanding</td></tr></tr></table>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -143,7 +148,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -152,7 +157,7 @@
        "0.0"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -171,7 +176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -180,7 +185,7 @@
        "(2e-08, 50000000.0)"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -192,7 +197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -205,7 +210,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "dc13837c0a354229b4154bbb1a88b78b",
+       "model_id": "6280b8a0551141928c80fe8cc2b19c15",
        "version_major": 2,
        "version_minor": 0
       },
@@ -236,13 +241,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<table><tr><th>id</th><th>Year</th><th>Date</th><th>Time</th><th>Name</th></tr><tr><tr><td>2</td><td>2019</td><td>Feb. 06</td><td>01:43:55 PM</td><td>NoSidebanding</td></tr><tr><td>3</td><td>2019</td><td>Feb. 06</td><td>01:43:55 PM</td><td>50MHz-Sidebanding</td></tr><tr><td>4</td><td>2019</td><td>Feb. 06</td><td>01:43:57 PM</td><td>50MHz-Sidebanding</td></tr><tr><td>5</td><td>2019</td><td>Feb. 06</td><td>01:43:55 PM</td><td>working</td></tr></tr></table>"
+       "<table><tr><th>id</th><th>Year</th><th>Date</th><th>Time</th><th>Name</th></tr><tr><tr><td>2</td><td>2019</td><td>Apr. 18</td><td>11:25:37 AM</td><td>NoSidebanding</td></tr><tr><td>3</td><td>2019</td><td>Apr. 18</td><td>11:25:38 AM</td><td>50MHz-Sidebanding</td></tr><tr><td>4</td><td>2019</td><td>Apr. 18</td><td>11:25:39 AM</td><td>50MHz-Sidebanding</td></tr><tr><td>5</td><td>2019</td><td>Apr. 18</td><td>11:25:38 AM</td><td>working</td></tr></tr></table>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -258,7 +263,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -267,13 +272,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<table><tr><th>id</th><th>Year</th><th>Date</th><th>Time</th><th>Name</th></tr><tr><tr><td>3</td><td>2019</td><td>Feb. 06</td><td>01:43:55 PM</td><td>50MHz-Sidebanding</td></tr><tr><td>4</td><td>2019</td><td>Feb. 06</td><td>01:43:57 PM</td><td>50MHz-Sidebanding</td></tr><tr><td>5</td><td>2019</td><td>Feb. 06</td><td>01:43:55 PM</td><td>working</td></tr></tr></table>"
+       "<table><tr><th>id</th><th>Year</th><th>Date</th><th>Time</th><th>Name</th></tr><tr><tr><td>3</td><td>2019</td><td>Apr. 18</td><td>11:25:38 AM</td><td>50MHz-Sidebanding</td></tr><tr><td>4</td><td>2019</td><td>Apr. 18</td><td>11:25:39 AM</td><td>50MHz-Sidebanding</td></tr><tr><td>5</td><td>2019</td><td>Apr. 18</td><td>11:25:38 AM</td><td>working</td></tr></tr></table>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -289,10 +294,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 12,
+   "metadata": {},
    "outputs": [],
    "source": [
     "cl.rm(\"50MHz-Sidebanding\")"
@@ -300,13 +303,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<table><tr><th>id</th><th>Year</th><th>Date</th><th>Time</th><th>Name</th></tr><tr><tr><td>5</td><td>2019</td><td>Feb. 06</td><td>01:43:55 PM</td><td>working</td></tr></tr></table>"
+       "<table><tr><th>id</th><th>Year</th><th>Date</th><th>Time</th><th>Name</th></tr><tr><tr><td>5</td><td>2019</td><td>Apr. 18</td><td>11:25:38 AM</td><td>working</td></tr></tr></table>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -337,7 +340,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.6.8"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
The new notation for X6 channels had not been updated for the Examples 1 and 2 notebooks. 
This PR corrects the notation .i.e uses `.ch(1)` rather than `'raw-1-1'` and `demodulated-1-1`
 