### PR TITLE
Allow an Experiment to be subclassed in a Jupyter notebook

### DIFF
--- a/src/auspex/experiment.py
+++ b/src/auspex/experiment.py
@@ -22,6 +22,14 @@ else:
     from multiprocessing import Process
     from threading import Thread as Thread
 
+from IPython.core.getipython import get_ipython
+in_notebook = False
+try:
+    get_ipython()
+    in_notebook = True
+except:
+    pass
+
 import inspect
 import time
 import copy
@@ -122,8 +130,11 @@ class MetaExperiment(type):
         # Beware, passing objects won't work at parse time
         self._output_connectors = {}
 
-        # Parse ourself
-        self._exp_src = inspect.getsource(self)
+        # Parse ourself -- can't do this if class is defined in a notebook (?)
+        if not in_notebook:
+            self._exp_src = inspect.getsource(self)
+        else:
+            self._exp_src = " "
 
         for k,v in dct.items():
             if isinstance(v, Instrument):


### PR DESCRIPTION
Check if we are running in a Jupyter notebook before attempting to call `inspect.parse` on an `Experiment`. @grahamrow, is this even necessary? Doesn't seem that `_exp_src` is used by anything but maybe it's nice to keep for legacy applications...