### PR TITLE
Fix/mux srs fix

### DIFF
--- a/src/auspex/experiment.py
+++ b/src/auspex/experiment.py
@@ -22,6 +22,14 @@ else:
     from multiprocessing import Process
     from threading import Thread as Thread
 
+from IPython.core.getipython import get_ipython
+in_notebook = False
+try:
+    get_ipython()
+    in_notebook = True
+except:
+    pass
+
 import inspect
 import time
 import copy
@@ -122,8 +130,11 @@ class MetaExperiment(type):
         # Beware, passing objects won't work at parse time
         self._output_connectors = {}
 
-        # Parse ourself
-        self._exp_src = inspect.getsource(self)
+        # Parse ourself -- can't do this if class is defined in a notebook (?)
+        if not in_notebook:
+            self._exp_src = inspect.getsource(self)
+        else:
+            self._exp_src = " "
 
         for k,v in dct.items():
             if isinstance(v, Instrument):

--- a/src/auspex/instruments/interface.py
+++ b/src/auspex/instruments/interface.py
@@ -44,8 +44,10 @@ class VisaInterface(Interface):
         self._resource.write_raw(raw_string)
     def read(self):
         return self._resource.read()
-    def read_raw(self):
-        return self._resource.read_raw()
+    def read_raw(self, size=None):
+        return self._resource.read_raw(size=size)
+    def read_bytes(self, count, chunk_size=None, break_on_termchar=False):
+        return self._resource.read_bytes(count, chunk_size=chunk_size, break_on_termchar=break_on_termchar)
     def query(self, query_string):
         return self._resource.query(query_string)
     def write_binary_values(self, query_string, values, **kwargs):

--- a/src/auspex/instruments/stanford.py
+++ b/src/auspex/instruments/stanford.py
@@ -84,7 +84,9 @@ class SR830(SCPIInstrument):
     def get_buffer(self, channel):
         stored_points = self.buffer_points
         self.interface.write("TRCB?{:d},0,{:d}".format(channel, stored_points))
-        buf = self.interface.read_raw()
+        #buf = self.interface.read_raw(numbytes=4)
+        buf = self.interface.read_bytes(4*stored_points,chunk_size=4)
+        logger.info(f"Raw buffer is {buf} with length {len(buf)} bytes.")
         return np.frombuffer(buf, dtype=np.float32)
 
     def buffer_start(self):

--- a/src/auspex/instruments/stanford.py
+++ b/src/auspex/instruments/stanford.py
@@ -109,8 +109,8 @@ class SR830(SCPIInstrument):
 
     def measure_delay(self):
         """Return how long we must wait for the values to have settled, based on the filter slope."""
-        fs = self.filter_slope
-        tc = self.time_constant
+        fs = float(self.filter_slope)
+        tc = float(self.time_constant)
         if fs <= 7: # 6dB/oct
             return 5*tc
         elif fs <= 13: # 12dB/oct
@@ -239,8 +239,8 @@ class SR865(SCPIInstrument):
 
     def measure_delay(self):
         """Return how long we must wait for the values to have settled, based on the filter slope."""
-        fs = self.filter_slope
-        tc = self.time_constant
+        fs = float(self.filter_slope)
+        tc = float(self.time_constant)
         if fs <= 7: # 6dB/oct
             return 5*tc
         elif fs <= 13: # 12dB/oct


### PR DESCRIPTION
Cast filter slope and time constant as floats in stanford.py
Added Channel delay commands to enable external measurement sweeps with Agilent MUX (agilent.py)
Merged fix to allow creation of Experiment class in Jupyter Notebook