### PR TITLE
Properly propagate stream descriptor datatype

### DIFF
--- a/src/auspex/experiment.py
+++ b/src/auspex/experiment.py
@@ -203,7 +203,8 @@ class Experiment(metaclass=MetaExperiment):
         # Things we can't metaclass
         self.output_connectors = {}
         for oc in self._output_connectors.keys():
-            a = OutputConnector(name=oc, data_name=oc, unit=self._output_connectors[oc].data_unit, parent=self)
+            a = OutputConnector(name=oc, data_name=oc, unit=self._output_connectors[oc].data_unit,
+                                dtype=self._output_connectors[oc].descriptor.dtype, parent=self)
             a.parent = self
 
             self.output_connectors[oc] = a

--- a/src/auspex/stream.py
+++ b/src/auspex/stream.py
@@ -587,7 +587,7 @@ class InputConnector(object):
         return "<InputConnector(name={})>".format(self.name)
 
 class OutputConnector(object):
-    def __init__(self, name="", data_name=None, unit=None, parent=None, datatype=None):
+    def __init__(self, name="", data_name=None, unit=None, parent=None, dtype=np.float32):
         self.name = name
         self.output_streams = []
         self.parent = parent
@@ -601,7 +601,7 @@ class OutputConnector(object):
 
         # Set up a default descriptor, and add access
         # to its methods for convenience.
-        self.descriptor = DataStreamDescriptor()
+        self.descriptor = DataStreamDescriptor(dtype=dtype)
         if self.data_name:
             self.descriptor.data_name = self.data_name
             self.descriptor.unit = self.unit


### PR DESCRIPTION
Make sure streams and in particular `OutputConnector` pass the relevant `dtype` around.