### PR TITLE
Reimplement readout optimization 

### DIFF
--- a/src/auspex/qubit/qubit_exp.py
+++ b/src/auspex/qubit/qubit_exp.py
@@ -486,7 +486,7 @@ class QubitExperiment(Experiment):
                 param.add_post_push_hook(lambda: time.sleep(0.05))
             else:
                 raise ValueError("The instrument {} has no method {}".format(name, "set_"+attribute))
-        # param.instr_tree = [instr.name, attribute] #TODO: extend tree to endpoint
+        param.instr_tree = [instr.name, attribute] #TODO: extend tree to endpoint
         self.add_sweep(param, values) # Create the requested sweep on this parameter
 
     def add_avg_sweep(self, num_averages):

--- a/src/auspex/qubit/qubit_exp.py
+++ b/src/auspex/qubit/qubit_exp.py
@@ -473,7 +473,7 @@ class QubitExperiment(Experiment):
                     getattr(instr, "set_"+prop)(chan, value, thing)
                 except:
                     getattr(instr, "set_"+prop)(chan, value)
-
+            param.set_pair = (thing.phys_chan.label, attribute)
 
         if method:
             # Custom method
@@ -486,7 +486,7 @@ class QubitExperiment(Experiment):
                 param.add_post_push_hook(lambda: time.sleep(0.05))
             else:
                 raise ValueError("The instrument {} has no method {}".format(name, "set_"+attribute))
-        param.instr_tree = [instr.name, attribute] #TODO: extend tree to endpoint
+            param.set_pair = (instr.name, attribute)
         self.add_sweep(param, values) # Create the requested sweep on this parameter
 
     def add_avg_sweep(self, num_averages):

--- a/src/auspex/qubit/single_shot_fidelity.py
+++ b/src/auspex/qubit/single_shot_fidelity.py
@@ -132,12 +132,12 @@ class SingleShotFidelityExperiment(QubitExperiment):
         return ssf
 
     def get_fidelity(self):
-        if self.pdf_data is None:
+        if not self.pdf_data:
             raise Exception("Could not find single shot PDF data in results. Did you run the sweeps?")
         return [p["Max I Fidelity"] for p in self.pdf_data]
 
     def get_threshold(self):
-        if self.pdf_data is None:
+        if not self.pdf_data:
             raise Exception("Could not find single shot PDF data in results. Did you run the sweeps?")
         return [p["I Threshold"] for p in self.pdf_data]
 

--- a/src/auspex/qubit/single_shot_fidelity.py
+++ b/src/auspex/qubit/single_shot_fidelity.py
@@ -32,8 +32,15 @@ from auspex.analysis.helpers import normalize_data
 import auspex.config
 
 class SingleShotFidelityExperiment(QubitExperiment):
-    """Experiment to measure single-shot measurement fidelity of a qubit."""
+    """Experiment to measure single-shot measurement fidelity of a qubit.
 
+        Args:
+            qubit:                          qubit object
+            output_nodes (optional):        the output node of the filter pipeline to use for single-shot readout. The default is choses, if single output.
+            meta_file (string, optional):   path to the QGL sequence meta_file. Default to standard SingleShot sequence
+            optimize (bool, optional):      if True and a qubit_sweep is added, set the parameter corresponding to the maximum measured fidelity at the end of the sweep
+
+    """
     def __init__(self, qubit, output_nodes=None, meta_file=None, optimize=True, **kwargs):
 
         self.pdf_data = []

--- a/src/auspex/qubit/single_shot_fidelity.py
+++ b/src/auspex/qubit/single_shot_fidelity.py
@@ -97,6 +97,18 @@ class SingleShotFidelityExperiment(QubitExperiment):
         if not self.sweeper.axes:
             self._update_histogram_plots()
             self.stop_manual_plotters()
+        else:
+            fidelities = [f['Max I Fidelity'] for f in self.pdf_data]
+            opt_ind = np.argmax(fidelities)
+            for k, axis in enumerate(self.sweeper.axes):
+                instr_tree = axis.parameter.instr_tree
+                opt_value = axis.points[opt_ind]
+                param_key = self.instruments
+                for key in instr_tree[:-1]:
+                    # go through the tree
+                    param_key = param_key[key]
+                #TODO: update database
+            pass
 
     def find_single_shot_filter(self):
         """Make sure there is one single shot measurement filter in the pipeline."""

--- a/src/auspex/qubit/single_shot_fidelity.py
+++ b/src/auspex/qubit/single_shot_fidelity.py
@@ -100,6 +100,7 @@ class SingleShotFidelityExperiment(QubitExperiment):
         else:
             fidelities = [f['Max I Fidelity'] for f in self.pdf_data]
             opt_ind = np.argmax(fidelities)
+            import pdb; pdb.set_trace()
             for k, axis in enumerate(self.sweeper.axes):
                 instr_tree = axis.parameter.instr_tree
                 opt_value = axis.points[opt_ind]


### PR DESCRIPTION
Simply set the optimal value to a swept instrument in a `SingleShotFidelityExperiment`. Close first part of https://github.com/BBN-Q/Auspex/issues/327