### PR TITLE
Shared memory filter pipeline and doneness improvements

### DIFF
--- a/src/auspex/filters/channelizer.py
+++ b/src/auspex/filters/channelizer.py
@@ -85,7 +85,7 @@ class Channelizer(Filter):
         self.idx = 0
 
         # For storing carryover if getting uneven buffers
-        self.carry = np.zeros(0, dtype=self.output_descriptor.dtype)
+        self.carry = np.zeros(0, dtype=self.source.descriptor.dtype)
 
 
     def update_references(self, frequency):
@@ -185,11 +185,8 @@ class Channelizer(Filter):
         decimated_descriptor.axes[-1].original_points = decimated_descriptor.axes[-1].points
         decimated_descriptor._exp_src = self.sink.descriptor._exp_src
         decimated_descriptor.dtype = np.complex64
-        self.output_descriptor = decimated_descriptor
-        for os in self.source.output_streams:
-            os.set_descriptor(decimated_descriptor)
-            if os.end_connector is not None:
-                os.end_connector.update_descriptors()
+        self.source.descriptor = decimated_descriptor
+        self.source.update_descriptors()
 
     def process_data(self, data):
 
@@ -210,7 +207,7 @@ class Channelizer(Filter):
             else:
                 self.carry = data
         else:
-            self.carry = np.zeros(0, dtype=self.output_descriptor.dtype)
+            self.carry = np.zeros(0, dtype=self.source.descriptor.dtype)
 
         if num_records > 0:
             # The records are processed in parallel after being reshaped here

--- a/src/auspex/filters/elementwise.py
+++ b/src/auspex/filters/elementwise.py
@@ -92,19 +92,20 @@ class ElementwiseFilter(Filter):
             for stream, messages in msgs_by_stream.items():
                 for message in messages:
                     message_type = message['type']
-                    message_data = message['data']
-                    message_data = message_data if hasattr(message_data, 'size') else np.array([message_data])
+                    # message_data = message['data']
+                    # message_data = message_data if hasattr(message_data, 'size') else np.array([message_data])
                     if message_type == 'event':
                         if message['event_type'] == 'done':
                             streams_done[stream] = True
                         elif message['event_type'] == 'refine':
                             logger.warning("ElementwiseFilter doesn't handle refinement yet!")
-                        self.push_to_all(message)
                     elif message_type == 'data':
                         # Add any old data...
-                        points_per_stream[stream] += len(message_data.flatten())
-                        stream_data[stream] = np.concatenate((stream_data[stream], message_data.flatten()))
-
+                        message_data = stream.pop()
+                        if message_data is not None:
+                            points_per_stream[stream] += len(message_data)
+                            stream_data[stream] = np.concatenate((stream_data[stream], message_data))
+                            # logger.info(f"{stream.name}: {message_data} now {stream_data[stream]}")
             # Now process the data with the elementwise operation
             smallest_length = min([d.size for d in stream_data.values()])
             new_data = [d[:smallest_length] for d in stream_data.values()]
@@ -123,5 +124,6 @@ class ElementwiseFilter(Filter):
 
             # If the amount of data processed is equal to the num points in the stream, we are done
             if np.all([streams_done[stream] for stream in streams]):
+                self.push_to_all({"type": "event", "event_type": "done", "data": None})
                 self.done.set()
                 break

--- a/src/auspex/filters/filter.py
+++ b/src/auspex/filters/filter.py
@@ -27,6 +27,7 @@ import itertools
 import time, datetime
 import queue
 import copy
+import ctypes
 import numpy as np
 
 from auspex.parameter import Parameter
@@ -74,6 +75,12 @@ class Filter(Process, metaclass=MetaFilter):
 
         # Keep track of data throughput
         self.processed = 0
+
+        # Shared memory interface
+        self.w_idx_shared = Value('i', 0)
+        self.r_idx_shared = Value('i', 0)
+        self.buff_shared_re = Array(ctypes.c_double, lock=True)
+        self.buff_shared_im = Array(ctypes.c_double, lock=True)
 
         # For objectively measuring doneness
         self.finished_processing = Event()

--- a/src/auspex/instruments/X6.py
+++ b/src/auspex/instruments/X6.py
@@ -252,7 +252,7 @@ class X6(Instrument):
                 length = int(self._lib.record_length/32)
             else: #Raw
                 length = int(self._lib.record_length/4)
-            buff = np.zeros((segs, length), dtype=np.float32)
+            buff = np.zeros((segs, length), dtype=chan.dtype)
             # for chan, wsock in self._chan_to_wsocket.items():
             for i in range(segs):
                 if chan.stream_type == "integrated":
@@ -270,6 +270,7 @@ class X6(Instrument):
                 buff = buff.astype(np.complex128) + random_mag*np.random.random((segs, length))+ 1j*random_mag*np.random.random((segs, length))
 
             total += length*segs
+            # logger.info(f"In Spew: {buff.dtype} {chan.dtype} {buff.size}")
             wsock.send(struct.pack('n', segs*length*buff.dtype.itemsize) + buff.flatten().tostring())
             counter[chan] += length*segs
 
@@ -303,6 +304,7 @@ class X6(Instrument):
                     logger.error("Expected %s bytes, received %s bytes" % (msg_size, len(buf)))
                     return
                 data = np.frombuffer(buf, dtype=channel.dtype)
+                # logger.info(f"X6 {msg_size} got {len(data)}")
                 total += len(data)
                 oc.push(data)
 
@@ -353,7 +355,7 @@ class X6(Instrument):
                         total_spewed += self.spew_fake_data(counter, self.ideal_data)
                 else:
                     total_spewed += self.spew_fake_data(counter, [0.0 for i in range(self.number_segments)])
-
+                # logger.info(f"Spewed {total_spewed}")
                 time.sleep(0.0001)
 
             self.ideal_counter += 1

--- a/src/auspex/instruments/X6.py
+++ b/src/auspex/instruments/X6.py
@@ -233,36 +233,45 @@ class X6(Instrument):
         # todo: other checking here
         self._channels.append(channel)
 
-    def spew_fake_data(self, counter, ideal_datapoint=0, random_mag=0.1, random_seed=12345):
+    def spew_fake_data(self, counter, ideal_data, random_mag=0.1, random_seed=12345):
         """
         Generate fake data on the stream. For unittest usage.
-        ideal_datapoint: mean of the expected signal for stream_type =  "Integrated".
+        ideal_data: array or list giving means of the expected signal for each segment
 
         Returns the total number of fake data points, so that we can
         keep track of how many we expect to receive, when we're doing
         the test with fake data
         """
         total = 0
-
+        # import ipdb; ipdb.set_trace();
+        segs = self._lib.nbr_segments
         for chan, wsock in self._chan_to_wsocket.items():
             if chan.stream_type == "integrated":
                 length = 1
-                data = random_mag*(np.random.random(length).astype(chan.dtype) + 1j*np.random.random(length).astype(chan.dtype)) + ideal_datapoint
             elif chan.stream_type == "demodulated":
                 length = int(self._lib.record_length/32)
-                data = np.zeros(length, dtype=chan.dtype)
-                data[int(length/4):int(3*length/4)] = 1.0 if ideal_datapoint == 0 else ideal_datapoint
-                data += random_mag*(np.random.random(length) + 1j*np.random.random(length))
             else: #Raw
                 length = int(self._lib.record_length/4)
-                signal = np.sin(np.linspace(0,10.0*np.pi,int(length/2)))
-                data = np.zeros(length, dtype=chan.dtype)
-                data[int(length/4):int(length/4)+len(signal)] = signal * (1.0 if ideal_datapoint == 0 else ideal_datapoint)
-                data += random_mag*np.random.random(length)
+            buff = np.zeros((segs, length), dtype=np.float32)
+            # for chan, wsock in self._chan_to_wsocket.items():
+            for i in range(segs):
+                if chan.stream_type == "integrated":
+                    # random_mag*(np.random.random(length).astype(chan.dtype) + 1j*np.random.random(length).astype(chan.dtype)) + 
+                    buff[i,:] = ideal_data[i]
+                elif chan.stream_type == "demodulated":
+                    buff[i, int(length/4):int(3*length/4)] = 1.0 if ideal_data[i] == 0 else ideal_data[i]
+                else: #Raw
+                    signal = np.sin(np.linspace(0,10.0*np.pi,int(length/2)))
+                    buff[i, int(length/4):int(length/4)+len(signal)] = signal * (1.0 if ideal_data[i] == 0 else ideal_data[i])
+            # import ipdb; ipdb.set_trace();
+            if chan.stream_type == "raw":
+                buff += random_mag*np.random.random((segs, length))
+            else:
+                buff = buff.astype(np.complex128) + random_mag*np.random.random((segs, length))+ 1j*random_mag*np.random.random((segs, length))
 
-            total += length
-            wsock.send(struct.pack('n', length*data.dtype.itemsize) + data.tostring())
-            counter[chan] += length
+            total += length*segs
+            wsock.send(struct.pack('n', segs*length*buff.dtype.itemsize) + buff.flatten().tostring())
+            counter[chan] += length*segs
 
         return total
 
@@ -332,24 +341,20 @@ class X6(Instrument):
             counter = {chan: 0 for chan in self._chan_to_wsocket.keys()}
             initial_points = {oc: oc.points_taken.value for oc in ocs}
             for j in range(self._lib.nbr_round_robins):
-                for i in range(self._lib.nbr_segments):
-                    if self.ideal_data is not None:
-                        #add ideal data for testing
-                        if hasattr(self, 'exp_step') and self.increment_ideal_data:
-                            raise Exception("Cannot use both exp_step and increment_ideal_data")
-                        elif hasattr(self, 'exp_step'):
-                            total_spewed += self.spew_fake_data(
-                                    counter, self.ideal_data[self.exp_step][i])
-                        elif self.increment_ideal_data:
-                            total_spewed += self.spew_fake_data(
-                                   counter, self.ideal_data[self.ideal_counter][i])
-                        else:
-                            total_spewed += self.spew_fake_data(
-                                    counter, self.ideal_data[i])
+                if self.ideal_data is not None:
+                    #add ideal data for testing
+                    if hasattr(self, 'exp_step') and self.increment_ideal_data:
+                        raise Exception("Cannot use both exp_step and increment_ideal_data")
+                    elif hasattr(self, 'exp_step'):
+                        total_spewed += self.spew_fake_data(counter, self.ideal_data[self.exp_step])
+                    elif self.increment_ideal_data:
+                        total_spewed += self.spew_fake_data(counter, self.ideal_data[self.ideal_counter])
                     else:
-                        total_spewed += self.spew_fake_data(counter)
+                        total_spewed += self.spew_fake_data(counter, self.ideal_data)
+                else:
+                    total_spewed += self.spew_fake_data(counter, [0.0 for i in range(self.number_segments)])
 
-                    time.sleep(0.0001)
+                time.sleep(0.0001)
 
             self.ideal_counter += 1
             # logger.info("Counter: %s", str(counter))

--- a/src/auspex/instruments/alazar.py
+++ b/src/auspex/instruments/alazar.py
@@ -114,7 +114,7 @@ class AlazarATS9870(Instrument):
         return self._lib.data_available()
 
     def done(self):
-        logger.warning(f"Checking alazar doneness: {self.total_received.value} {self.number_segments * self.number_averages * self.record_length}")
+        # logger.warning(f"Checking alazar doneness: {self.total_received.value} {self.number_segments * self.number_averages * self.record_length}")
         return self.total_received.value >=  (self.number_segments * self.number_averages * self.record_length)
 
     def get_socket(self, channel):
@@ -191,7 +191,7 @@ class AlazarATS9870(Instrument):
             self.total_received.value += len(data)
             if datetime.datetime.now().timestamp() - last_print > 0.25:
                 last_print = datetime.datetime.now().timestamp()
-                logger.info(f"Alz: {self.total_received.value}")
+                # logger.info(f"Alz: {self.total_received.value}")
             oc.push(data)
             self.fetch_count.value += 1
 

--- a/src/auspex/qubit/qubit_exp.py
+++ b/src/auspex/qubit/qubit_exp.py
@@ -417,7 +417,7 @@ class QubitExperiment(Experiment):
             listener.start()
 
         while ready.value < len(self.chan_to_dig):
-            time.sleep(0.3)
+            time.sleep(0.1)
 
         if self.cw_mode:
             for awg in self.awgs:

--- a/src/auspex/qubit/qubit_exp.py
+++ b/src/auspex/qubit/qubit_exp.py
@@ -120,7 +120,10 @@ class QubitExperiment(Experiment):
         self.controlled_qubits = [c for c in self.chan_db.channels if c.label in meta_info["qubits"]]
         self.measurements      = [c for c in self.chan_db.channels if c.label in meta_info["measurements"]]
         self.measured_qubits   = [c for c in self.chan_db.channels if "M-"+c.label in meta_info["measurements"]]
-        self.edges             = [c for c in self.chan_db.channels if c.label in meta_info["edges"]]
+        if 'edges' in meta_info:
+            self.edges             = [c for c in self.chan_db.channels if c.label in meta_info["edges"]]
+        else:
+            self.edges = []
         self.phys_chans        = list(set([e.phys_chan for e in self.controlled_qubits + self.measurements + self.edges]))
         self.transmitters      = list(set([e.phys_chan.transmitter for e in self.controlled_qubits + self.measurements + self.edges]))
         self.receiver_chans    = list(set([e.receiver_chan for e in self.measurements]))

--- a/src/auspex/stream.py
+++ b/src/auspex/stream.py
@@ -489,7 +489,7 @@ class DataStream(object):
 
         # Shared memory interface
         self.buffer_lock    = mp.Lock()
-        self.buffer_size    = 5000000
+        self.buffer_size    = 500000
         self.buff_idx       = Value('i', 0)
         self.buff_shared_re = RawArray(ctypes.c_double, self.buffer_size)
         self.buff_shared_im = RawArray(ctypes.c_double, self.buffer_size)

--- a/src/auspex/stream.py
+++ b/src/auspex/stream.py
@@ -555,7 +555,7 @@ class DataStream(object):
             # logger.info(f"in buff_shared_re:{self.buff_idx.value}  {re[0:4]}")
             self.re_np[start:start+re.size] = re
             if issubclass(self.descriptor.dtype, np.complex):
-                im = np.real(data).flatten()
+                im = np.imag(data).flatten()
                 # logger.info(f"in buff_shared_im:{self.buff_idx.value}  {im[0:4]}")
                 self.im_np[start:start+im.size] = im
             message = {"type": "data", "data": None}

--- a/src/auspex/stream.py
+++ b/src/auspex/stream.py
@@ -494,7 +494,7 @@ class DataStream(object):
         self.buff_shared_re = RawArray(ctypes.c_double, self.buffer_size)
         self.buff_shared_im = RawArray(ctypes.c_double, self.buffer_size)
         self.re_np = np.frombuffer(self.buff_shared_re, dtype=np.float64)
-        self.im_np = np.frombuffer(self.buff_shared_re, dtype=np.float64)
+        self.im_np = np.frombuffer(self.buff_shared_im, dtype=np.float64)
 
     def set_descriptor(self, descriptor):
         if isinstance(descriptor,DataStreamDescriptor):
@@ -552,11 +552,9 @@ class DataStream(object):
         with self.buffer_lock:
             start = self.buff_idx.value
             re = np.real(data).flatten()
-            # logger.info(f"in buff_shared_re:{self.buff_idx.value}  {re[0:4]}")
             self.re_np[start:start+re.size] = re
-            if issubclass(self.descriptor.dtype, np.complex):
+            if np.issubdtype(self.descriptor.dtype, np.complexfloating):
                 im = np.imag(data).flatten()
-                # logger.info(f"in buff_shared_im:{self.buff_idx.value}  {im[0:4]}")
                 self.im_np[start:start+im.size] = im
             message = {"type": "data", "data": None}
             self.buff_idx.value = start + data.size
@@ -568,8 +566,8 @@ class DataStream(object):
             idx = self.buff_idx.value
             if idx != 0:
                 result = self.re_np[:idx]
-                # logger.info(f"out buff_shared: {idx} {result[0:4]}")
-                if issubclass(self.descriptor.dtype, np.complex):
+
+                if np.issubdtype(self.descriptor.dtype, np.complexfloating):
                     result = result.astype(np.complex128) + 1.0j*self.im_np[:idx]
                 self.buff_idx.value = 0
                 result = result.copy()

--- a/test/test_alazar.py
+++ b/test/test_alazar.py
@@ -84,7 +84,7 @@ class AlazarTestCase(unittest.TestCase):
         alz.wait_for_acquisition(run, timeout=5, ocs=[oc])
 
         exit.set()
-        time.sleep(1)
+        time.sleep(0.1)
         proc.join(3.0)
         if proc.is_alive():
             proc.terminate()
@@ -121,7 +121,7 @@ class AlazarTestCase(unittest.TestCase):
         exp.set_fake_data(dig_1, np.cos(np.linspace(-np.pi, np.pi, 51)))
         exp.run_sweeps()
         data, desc = exp.buffers[0].get_data()
-        self.assertAlmostEqual(np.abs(data).sum(),459.2,places=0)
+        self.assertAlmostEqual(np.abs(data).sum(),610.5,places=0)
 
 if __name__ == '__main__':
     unittest.main() 

--- a/test/test_alazar.py
+++ b/test/test_alazar.py
@@ -121,7 +121,7 @@ class AlazarTestCase(unittest.TestCase):
         exp.set_fake_data(dig_1, np.cos(np.linspace(-np.pi, np.pi, 51)))
         exp.run_sweeps()
         data, desc = exp.buffers[0].get_data()
-        self.assertAlmostEqual(np.abs(data).sum(),610.5,places=0)
+        self.assertAlmostEqual(np.abs(data).sum(),459.1,places=0)
 
 if __name__ == '__main__':
     unittest.main() 

--- a/test/test_buffer.py
+++ b/test/test_buffer.py
@@ -58,7 +58,7 @@ class SweptTestExperiment(Experiment):
         time_step = 0.1
         time.sleep(0.002)
         if self.complex_data:
-            data_row = np.exp(2j*np.pi*self.time_val)*np.ones(5) + 0.1j*np.random.random(5)
+            data_row = np.sin(2*np.pi*self.time_val)*np.ones(5) + 2.0j*np.sin(2*np.pi*self.time_val)*np.ones(5)
         else:
             data_row = np.sin(2*np.pi*self.time_val)*np.ones(5) + 0.1*np.random.random(5)
         self.time_val += time_step
@@ -160,8 +160,7 @@ class BufferTestCase(unittest.TestCase):
 
         data, desc = db.get_data()
 
-        self.assertAlmostEqual(np.sum(data.real-data.imag), 0.0, places=3)
-        # self.assertTrue(np.all(desc['field'] == np.linspace(0,100.0,4)))
+        self.assertAlmostEqual(np.mean(data.imag)/np.mean(data.real), 2.0, places=3)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_correlator.py
+++ b/test/test_correlator.py
@@ -23,8 +23,6 @@ class CorrelatorExperiment(Experiment):
 
     # Constants
     samples = 100
-    idx_1   = 0
-    idx_2   = 0
 
     # For correlator verification
     vals = 2.0 + np.linspace(0, 10*np.pi, samples)
@@ -35,16 +33,19 @@ class CorrelatorExperiment(Experiment):
 
     def run(self):
         logger.debug("Data taker running (inner loop)")
-
+        np.random.seed(12345)
+        self.idx_1   = 0
+        self.idx_2   = 0
         while self.idx_1 < self.samples or self.idx_2 < self.samples:
-
+            # print(self.idx_1, self.idx_2)
             # Generate random number of samples:
-            new_1 = np.random.randint(1,5)
-            new_2 = np.random.randint(1,5)
+            new_1 = np.random.randint(2,5)
+            new_2 = np.random.randint(2,5)
 
             if self.chan1.points_taken.value < self.chan1.num_points():
                 if self.chan1.points_taken.value + new_1 > self.chan1.num_points():
                     new_1 = self.chan1.num_points() - self.chan1.points_taken.value
+                # logger.info(f"C1 push {self.vals[self.idx_1:self.idx_1+new_1]}")
                 self.chan1.push(self.vals[self.idx_1:self.idx_1+new_1])
                 self.idx_1 += new_1
             if self.chan2.points_taken.value < self.chan2.num_points():
@@ -52,6 +53,7 @@ class CorrelatorExperiment(Experiment):
                     new_2 = self.chan2.num_points() - self.chan2.points_taken.value
                 self.chan2.push(self.vals[self.idx_2:self.idx_2+new_2])
                 self.idx_2 += new_2
+                # logger.info(f"C2 push {self.vals[self.idx_2:self.idx_2+new_2]}")
 
             time.sleep(0.002)
             logger.debug("Idx_1: %d, Idx_2: %d", self.idx_1, self.idx_2)
@@ -69,10 +71,10 @@ class CorrelatorTestCase(unittest.TestCase):
 
         exp.set_graph(edges)
         exp.run_sweeps()
-        time.sleep(0.1)
+        time.sleep(0.01)
         corr_data     = buff.output_data
         expected_data = exp.vals*exp.vals
-        self.assertAlmostEqual(np.sum(corr_data), np.sum(expected_data), places=1)
+        self.assertAlmostEqual(np.sum(corr_data), np.sum(expected_data), places=0)
 
 
 if __name__ == '__main__':

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -163,7 +163,7 @@ class PipelineTestCase(unittest.TestCase):
 
         self.assertTrue(len(exp.buffers)==2)
  
-    def test_run_direct(self):
+    def test_run_pipeline(self):
         cl.clear()
         q1    = cl.new_qubit("q1")
         aps1  = cl.new_APS2("BBNAPS1", address="192.168.5.102")


### PR DESCRIPTION
Now use queues in DataStreams only for messages. Data is transferred through two shared memory arrays, one each for real and imaginary data components. Write index is another shared value.