### PR TITLE
Make chan db saving optional

### DIFF
--- a/src/auspex/experiment.py
+++ b/src/auspex/experiment.py
@@ -205,6 +205,9 @@ class Experiment(metaclass=MetaExperiment):
         # add date to data files?
         self.add_date = False
 
+        # save channel library
+        self.save_chanddb = False
+
         # Things we can't metaclass
         self.output_connectors = {}
         for oc in self._output_connectors.keys():
@@ -514,7 +517,7 @@ class Experiment(metaclass=MetaExperiment):
                 w.filename.value = inc_filename
         self.filenames = [w.filename.value for w in self.writers]
         # Save ChannelLibrary version
-        if hasattr(self, 'chan_db') and self.filenames:
+        if hasattr(self, 'chan_db') and self.filenames and self.save_chandb:
             import bbndb
             exp_chandb = bbndb.deepcopy_sqla_object(self.chan_db, self.cl_session)
             exp_chandb.label = os.path.basename(self.filenames[0])

--- a/src/auspex/qubit/qubit_exp.py
+++ b/src/auspex/qubit/qubit_exp.py
@@ -68,7 +68,7 @@ class QubitExperiment(Experiment):
 
     """
 
-    def __init__(self, meta_file, averages=100, exp_name=None, **kwargs):
+    def __init__(self, meta_file, averages=100, exp_name=None, save_chandb=True, **kwargs):
         super(QubitExperiment, self).__init__(**kwargs)
 
         if not pipeline.pipelineMgr:
@@ -82,6 +82,7 @@ class QubitExperiment(Experiment):
 
         self.outputs_by_qubit = {}
         self.progressbars = None
+        self.save_chandb = save_chandb
 
         self.create_from_meta(meta_file, averages)
 


### PR DESCRIPTION
Make it optional to save the exp. configuration settings, in cases where the same experiments are run in a loop and the info is redundant. In any case, for reference, a database of ~170 single-qubit experiments takes only 500 kB