### PR TITLE
Match metadata to the corresponding data

### DIFF
--- a/src/auspex/qubit/pulse_calibration.py
+++ b/src/auspex/qubit/pulse_calibration.py
@@ -198,6 +198,12 @@ class QubitCalibration(Calibration):
 
         data = {}
         var = {}
+
+        #sort nodes by qubit name to match data with metadata when normalizing
+        qubit_indices = {q.label: idx for idx, q in enumerate(exp.qubits)}
+        exp.output_nodes.sort(key=lambda x: qubit_indices[x.qubit_name])
+        exp.var_buffers.sort(key=lambda x: qubit_indices[x.qubit_name])
+
         for i, (qubit, output_buff, var_buff) in enumerate(zip(exp.qubits,
                                 [exp.proxy_to_filter[on] for on in exp.output_nodes],
                                 [exp.proxy_to_filter[on] for on in exp.var_buffers])):


### PR DESCRIPTION
Make sure that data and metadata are sorted in the same order, so that `normalize_buffer_data` finds the correct normalization points

https://github.com/BBN-Q/Auspex/blob/6531b7e38a143102c95fd778b109de0cdc91423a/src/auspex/analysis/helpers.py#L93-L95

Fix https://github.com/BBN-Q/Auspex/issues/396