### PR TITLE
Fix normalize data ordering to avoid complex data.

### DIFF
--- a/src/auspex/analysis/helpers.py
+++ b/src/auspex/analysis/helpers.py
@@ -1,4 +1,5 @@
 from auspex.data_format import AuspexDataContainer
+from auspex.log import logger
 import datetime
 import os, re
 from os import path
@@ -75,6 +76,9 @@ def open_data(num=None, folder=None, groupname="main", datasetname="data", date=
 
 
 def normalize_data(data, zero_id = 0, one_id = 1):
+    if np.any(np.iscomplex(data['Data'])):
+        logger.warning("normalize_data should not be used with complex data.")
+
     metadata_str = [f for f in data.dtype.fields.keys() if 'metadata' in f]
     if len(metadata_str)!=1:
         raise ValueError('Data format not valid')
@@ -94,6 +98,9 @@ def normalize_data(data, zero_id = 0, one_id = 1):
     return norm_data
 
 def normalize_buffer_data(data, desc, qubit_index, zero_id = 0, one_id = 1):
+    if np.any(np.iscomplex(data)):
+        logger.warning("normalize_buffer_data should not be used with complex data.")
+
     # Qubit index gives the string offset of the qubit in the metadata
     metadata = [(i, int(v[qubit_index])) for i,v in enumerate(desc.axes[0].metadata) if v != "data"]
 

--- a/src/auspex/qubit/pulse_calibration.py
+++ b/src/auspex/qubit/pulse_calibration.py
@@ -212,6 +212,7 @@ class QubitCalibration(Calibration):
                 raise ValueError("Could not find data buffer for calibration.")
 
             dataset, descriptor = output_buff.get_data()
+            dataset = self.quad_fun(dataset)
 
             if self.norm_points:
                 buff_data = normalize_buffer_data(dataset, descriptor, i, zero_id=self.norm_points[qubit.label][0],
@@ -219,7 +220,7 @@ class QubitCalibration(Calibration):
             else:
                 buff_data = dataset
 
-            data[qubit.label] = self.quad_fun(buff_data)
+            data[qubit.label] = buff_data
 
             var_dataset, var_descriptor = var_buff.get_data()
             # if 'Variance' in dataset.dtype.names:
@@ -1253,6 +1254,8 @@ def phase_to_amplitude(phase, sigma, amp, target, epsilon=1e-2):
     return amp, done_flag, phase_error
 
 def quick_norm_data(data): #TODO: generalize as in Qlab.jl
+    if np.any(np.iscomplex(data)):
+        logger.warning("quick_norm_data does not support complex data!")
     """Rescale data assuming 2 calibrations / single qubit state at the end of the sequence"""
     data = 2*(data-np.mean(data[-4:-2]))/(np.mean(data[-4:-2])-np.mean(data[-2:])) + 1
     data = data[:-4]


### PR DESCRIPTION
Normalization functions were dividing data by the complex difference in cal states, causing all sorts of nonsense. Now we choose the quadrature before normalizing.