### PR TITLE
Respect bbndb object lockdown in qubit_exp and mixer_cal

### DIFF
--- a/src/auspex/qubit/mixer_calibration.py
+++ b/src/auspex/qubit/mixer_calibration.py
@@ -279,7 +279,9 @@ class MixerCalibrationExperiment(Experiment):
             instr = instrument_map[instrument.model](instrument.address, instrument.label) # Instantiate
             # For easy lookup
             instr.proxy_obj = instrument
+            instrument._locked = False
             instrument.instr = instr
+            instrument._locked = True
             # Add to the experiment's instrument list
             self._instruments[instrument.label] = instr
             self.instruments.append(instr)

--- a/src/auspex/qubit/qubit_exp.py
+++ b/src/auspex/qubit/qubit_exp.py
@@ -209,7 +209,7 @@ class QubitExperiment(Experiment):
         # Now a pipeline exists, so we create Auspex filters from the proxy filters in the db
         self.proxy_to_filter          = {}
         self.filters                  = []
-        self.connector_by_sel          = {}
+        self.connector_by_sel         = {}
         self.chan_to_dig              = {}
         self.chan_to_oc               = {}
         self.qubit_to_dig             = {}
@@ -238,7 +238,10 @@ class QubitExperiment(Experiment):
             instr = instrument_map[instrument.model](address, instrument.label) # Instantiate
             # For easy lookup
             instr.proxy_obj = instrument
+            
+            instrument._locked = False
             instrument.instr = instr # This shouldn't be relied upon
+            instrument._locked = True
 
             self.proxy_name_to_instrument[instrument.label] = instr
 


### PR DESCRIPTION
Protect the database ORM class instances from unknown attribute access in bbndb, need to use the following sort of logic:
```python
instrument._locked = False
instrument.instr = instr
# Other changes here
instrument._locked = True
```