### PR TITLE
Correlator node needs a pipeline manager

### DIFF
--- a/src/auspex/qubit/pipeline.py
+++ b/src/auspex/qubit/pipeline.py
@@ -98,7 +98,6 @@ class PipelineManager(object):
         q1_label = input_stream1.qubit_name
         q2_label = input_stream2.qubit_name
         select = adb.Correlate(qubit_name=f'{q1_label}-{q2_label}', label=f'Correlate {q1_label}{q2_label}')
-        # select.pipelineMgr = self
         self.session.add(select)
         self.meas_graph.add_node(select.hash_val, node_obj=select)
         self.meas_graph.add_edge(input_stream1.hash_val, select.hash_val, connector_in = 'sink', connector_out='source')

--- a/src/auspex/qubit/pipeline.py
+++ b/src/auspex/qubit/pipeline.py
@@ -98,6 +98,7 @@ class PipelineManager(object):
         q1_label = input_stream1.qubit_name
         q2_label = input_stream2.qubit_name
         select = adb.Correlate(qubit_name=f'{q1_label}-{q2_label}', label=f'Correlate {q1_label}{q2_label}')
+        select.pipelineMgr = self
         self.session.add(select)
         self.meas_graph.add_node(select.hash_val, node_obj=select)
         self.meas_graph.add_edge(input_stream1.hash_val, select.hash_val, connector_in = 'sink', connector_out='source')

--- a/src/auspex/qubit/pipeline.py
+++ b/src/auspex/qubit/pipeline.py
@@ -70,10 +70,10 @@ class PipelineManager(object):
                 node.pipelineMgr = self
                 self.meas_graph.add_node(node.hash_val, node_obj=node)
             self.meas_graph.add_edges_from(edges)
-            adb.__current_pipeline__ = self
         else:
-            logger.info("Could not find an existing pipeline. Please create one.")
+            logger.info("Could not find an existing pipeline. Creating a blank pipeline.")
 
+        adb.__current_pipeline__ = self
         pipelineMgr = self
 
     def add_qubit_pipeline(self, qubit_label, stream_type, auto_create=True, buffers=False):
@@ -84,7 +84,7 @@ class PipelineManager(object):
             raise Exception(f"Could not find qubit {qubit_label} in pipeline...")
 
         ss_label = qubit_label+"-"+stream_type
-        select = adb.StreamSelect(pipelineMgr=self, stream_type=stream_type, qubit_name=qubit_label, label=ss_label)
+        select = adb.StreamSelect(stream_type=stream_type, qubit_name=qubit_label, label=ss_label)
         self.session.add(select)
         if not self.meas_graph:
             self.meas_graph = nx.DiGraph()
@@ -98,7 +98,7 @@ class PipelineManager(object):
         q1_label = input_stream1.qubit_name
         q2_label = input_stream2.qubit_name
         select = adb.Correlate(qubit_name=f'{q1_label}-{q2_label}', label=f'Correlate {q1_label}{q2_label}')
-        select.pipelineMgr = self
+        # select.pipelineMgr = self
         self.session.add(select)
         self.meas_graph.add_node(select.hash_val, node_obj=select)
         self.meas_graph.add_edge(input_stream1.hash_val, select.hash_val, connector_in = 'sink', connector_out='source')
@@ -143,7 +143,7 @@ class PipelineManager(object):
             initial_stream_qubit = group[0]
             labels = [q.label for q in group]
             group_label = '-'.join(labels)
-            stream_selectors[group_label] = {'default' : adb.StreamSelect(pipelineMgr=self, label = group_label)}
+            stream_selectors[group_label] = {'default' : adb.StreamSelect(label = group_label)}
 
         for sels in stream_selectors.values():
             sel = sels['default']

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -83,6 +83,48 @@ class PipelineTestCase(unittest.TestCase):
         self.assertTrue(len(exp.output_connectors["q1-raw"].descriptor.axes) == 2)
         self.assertTrue(len(exp.output_connectors["q1-raw"].descriptor.axes[0].points) == 5)
 
+    def test_create_correlator(self):
+        """Create a mildly non-trivial pipeline"""
+        cl.clear()
+        q1    = cl.new_qubit("q1")
+        q2    = cl.new_qubit("q2")
+        aps1  = cl.new_APS2("BBNAPS1", address="192.168.5.102")
+        aps2  = cl.new_APS2("BBNAPS2", address="192.168.5.103")
+        aps3  = cl.new_APS2("BBNAPS3", address="192.168.5.104")
+        aps4  = cl.new_APS2("BBNAPS4", address="192.168.5.105")
+        x6_1  = cl.new_X6("X6_1", address="1", record_length=512)
+        x6_2  = cl.new_X6("X6_2", address="1", record_length=512)
+        holz1 = cl.new_source("Holz_1", "HolzworthHS9000", "HS9004A-009-1", power=-30)
+        holz2 = cl.new_source("Holz_2", "HolzworthHS9000", "HS9004A-009-2", power=-30)
+        holz3 = cl.new_source("Holz_3", "HolzworthHS9000", "HS9004A-009-3", power=-30)
+        holz4 = cl.new_source("Holz_4", "HolzworthHS9000", "HS9004A-009-4", power=-30)
+
+        cl.set_control(q1, aps1, generator=holz1)
+        cl.set_measure(q1, aps2, x6_1[1], generator=holz2)
+        cl.set_control(q2, aps3, generator=holz3)
+        cl.set_measure(q2, aps4, x6_2[1], generator=holz4)
+        cl.set_master(aps1, aps1.ch("m2"))
+        cl.commit()
+
+        pl.create_default_pipeline()
+        pl.add_correlator(pl["q1"]["Demodulate"]["Integrate"], pl["q2"]["Demodulate"]["Integrate"])
+        for ql in ['q1', 'q2']:
+            qb = cl[ql]
+            pl[ql].clear_pipeline()
+            pl[ql].stream_type = "integrated"
+            pl[ql].create_default_pipeline(buffers=False)
+
+            pl[ql]["Demodulate"]["Integrate"]["Average"].add(Write(label='var'), connector_out='final_variance')
+            pl[ql]["Demodulate"]["Integrate"]["Average"]["var"].groupname = ql + '-main'
+            pl[ql]["Demodulate"]["Integrate"]["Average"]["var"].datasetname = 'variance'
+
+        pl["q1"]["Demodulate"]["Integrate"]["Correlate"].add(Average(label='corr_avg')).add(Display(label='test_corr_avg',plot_dims=0))
+        pl["q1"]["Demodulate"]["Integrate"]["Correlate"]["Average"].add(Write(label='corr_write'))
+        pl["q1"]["Demodulate"]["Integrate"]["Correlate"]["Average"].add(Write(label='corr_var'), connector_out='final_variance')
+        pl.reset_pipelines()
+
+        exp = QubitExperiment(PulsedSpec(q1), averages=5)
+
     def test_create_transceiver(self):
         cl.clear()
         q1    = cl.new_qubit("q1")


### PR DESCRIPTION
The correlator node doesn't inherit the pipelineMgr in the current code base.  How did this ever work? 