### PR TITLE
Add option to create blank pipeline and ignore working one

### DIFF
--- a/src/auspex/qubit/pipeline.py
+++ b/src/auspex/qubit/pipeline.py
@@ -45,7 +45,7 @@ def check_session_dirty(f):
 
 class PipelineManager(object):
     """Create and run Qubit Experiments."""
-    def __init__(self):
+    def __init__(self, force_new=False):
         global pipelineMgr
 
         self.pipeline      = None
@@ -58,7 +58,7 @@ class PipelineManager(object):
 
         # Check to see whether there is already a temp database
         available_pipelines = list(set([pn[0] for pn in list(self.session.query(adb.Connection.pipeline_name).all())]))
-        if "working" in available_pipelines:
+        if "working" in available_pipelines and not force_new:
             connections = self.get_connections_by_name('working')
             edges = [(c.node1.hash_val, c.node2.hash_val, {'connector_in':c.node2_name,  'connector_out':c.node1_name}) for c in connections]
             nodes = []


### PR DESCRIPTION
Problem: we want to initialize a completely blank pipeline, but when we load the pipeline manager it automatically initializes it with our working pipeline. Create_default_pipeline creates a pipeline from the raw stream by default, but we want an integrated stream. We also noticed that the clear_pipelines() method leaves the stream selector nodes and therefore it cannot be used to completely remove the existing stream selectors.

The solution we came up with is adding a force_new option when the pipeline manager is initialized with instruction to ignore the "working" pipeline and create a blank pipeline instead. 

Graham: do you have a better solution in mind? An alternative could be to have a new create_blank_pipeline method maybe?