### PR TITLE
Set threshold of appropriate stream selector

### DIFF
--- a/src/auspex/qubit/single_shot_fidelity.py
+++ b/src/auspex/qubit/single_shot_fidelity.py
@@ -122,7 +122,8 @@ class SingleShotFidelityExperiment(QubitExperiment):
             self._update_histogram_plots()
             self.stop_manual_plotters()
             if self.set_threshold:
-                self.stream_selectors[0].threshold = self.get_threshold()[0]
+                stream_sel = [s for s in self.stream_selectors if s.qubit_name == self.measured_qubits[0].label][0]
+                stream_sel.threshold = self.get_threshold()[0]
             if self.sample:
                 c = bbndb.calibration.Calibration(value=self.get_fidelity()[0], sample=self.sample, name="Readout fid.", category="Readout")
                 c.date = datetime.datetime.now()


### PR DESCRIPTION
There may be multiple stream selectors, even if a graph with a single output is constructed