### PR TITLE
Updated ChannelLibrary() declarations to avoid using resource_name

### DIFF
--- a/doc/examples/Example-APS2-2Qubit.ipynb
+++ b/doc/examples/Example-APS2-2Qubit.ipynb
@@ -54,7 +54,7 @@
    "outputs": [],
    "source": [
     "# this will all be system dependent\n",
-    "cl = ChannelLibrary(db_resource_name=\":memory:\")\n",
+    "cl = ChannelLibrary(\":memory:\")\n",
     "\n",
     "q1 = cl.new_qubit(\"q1\")\n",
     "q2 = cl.new_qubit(\"q2\")\n",

--- a/doc/examples/Example-Calibrations.ipynb
+++ b/doc/examples/Example-Calibrations.ipynb
@@ -33,7 +33,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cl = ChannelLibrary(db_resource_name=\"my_config.sqlite\")\n",
+    "cl = ChannelLibrary(\"my_config\")\n",
     "pl = PipelineManager()"
    ]
   },

--- a/doc/examples/Example-Channel-Lib.ipynb
+++ b/doc/examples/Example-Channel-Lib.ipynb
@@ -45,7 +45,7 @@
    "source": [
     "from QGL import *\n",
     "\n",
-    "cl = ChannelLibrary(db_resource_name=\":memory:\")\n",
+    "cl = ChannelLibrary(\":memory:\")\n",
     "q1 = cl.new_qubit(\"q1\")\n",
     "aps2_1 = cl.new_APS2(\"BBNAPS1\", address=\"192.168.5.101\") \n",
     "aps2_2 = cl.new_APS2(\"BBNAPS2\", address=\"192.168.5.102\")\n",

--- a/doc/examples/Example-Config.ipynb
+++ b/doc/examples/Example-Config.ipynb
@@ -62,7 +62,7 @@
     }
    ],
    "source": [
-    "cl = ChannelLibrary(db_resource_name=\":memory:\")"
+    "cl = ChannelLibrary(\":memory:\")"
    ]
   },
   {

--- a/doc/examples/Example-Datafiles.ipynb
+++ b/doc/examples/Example-Datafiles.ipynb
@@ -59,7 +59,7 @@
    ],
    "source": [
     "# a minimal example of a qubit control chain\n",
-    "cl = ChannelLibrary(db_resource_name=\":memory:\")\n",
+    "cl = ChannelLibrary(\":memory:\")\n",
     "q2 = cl.new_qubit(\"q2\")\n",
     "\n",
     "# specify the particulars for a rack of APS2s\n",

--- a/doc/examples/Example-Experiments.ipynb
+++ b/doc/examples/Example-Experiments.ipynb
@@ -55,7 +55,7 @@
     }
    ],
    "source": [
-    "cl = ChannelLibrary(db_resource_name=\":memory:\")\n",
+    "cl = ChannelLibrary(\":memory:\")\n",
     "pl = PipelineManager()\n",
     "\n",
     "q1 = cl.new_qubit(\"q1\")\n",

--- a/doc/examples/Example-Filter-Pipeline.ipynb
+++ b/doc/examples/Example-Filter-Pipeline.ipynb
@@ -33,7 +33,7 @@
    "source": [
     "from QGL import *\n",
     "\n",
-    "cl = ChannelLibrary(db_resource_name=\":memory:\")\n",
+    "cl = ChannelLibrary(\":memory:\")\n",
     "\n",
     "# Create five qubits and supporting hardware\n",
     "for i in range(5):\n",

--- a/doc/examples/Example-SingleShot-Fid.ipynb
+++ b/doc/examples/Example-SingleShot-Fid.ipynb
@@ -48,7 +48,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cl = ChannelLibrary(db_resource_name=\"my_config.sqlite\")\n",
+    "cl = ChannelLibrary(\"my_config\")\n",
     "pl = PipelineManager()"
    ]
   },

--- a/doc/examples/Example-Sweeps.ipynb
+++ b/doc/examples/Example-Sweeps.ipynb
@@ -66,7 +66,7 @@
     }
    ],
    "source": [
-    "cl = ChannelLibrary(db_resource_name=\":memory:\")\n",
+    "cl = ChannelLibrary(\":memory:\")\n",
     "pl = PipelineManager()\n",
     "\n",
     "q1 = cl.new_qubit(\"q1\")\n",

--- a/test/test_alazar.py
+++ b/test/test_alazar.py
@@ -102,7 +102,7 @@ class AlazarTestCase(unittest.TestCase):
         self.basic(delay=1.0, averages=100)
 
     def test_qubit_experiment(self):
-        cl = ChannelLibrary(db_resource_name=":memory:")
+        cl = ChannelLibrary(":memory:")
         pl = PipelineManager()
         cl.clear()
         q1     = cl.new_qubit("q1")

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -41,7 +41,7 @@ class PipelineTestCase(unittest.TestCase):
     def setUpClass(cls):
         global cl, pl
 
-        cl = ChannelLibrary(db_resource_name=":memory:")
+        cl = ChannelLibrary(":memory:")
         pl = PipelineManager()
 
     def test_create(self):

--- a/test/test_pulsecal.py
+++ b/test/test_pulsecal.py
@@ -111,7 +111,7 @@ class SingleQubitCalTestCase(unittest.TestCase):
     def setUpClass(cls):
         global cl, pl
 
-        cl = ChannelLibrary(db_resource_name=":memory:")
+        cl = ChannelLibrary(":memory:")
         pl = PipelineManager()
 
     def _setUp(self, num_averages=50):
@@ -288,7 +288,7 @@ class TwoQubitCalTestCase(unittest.TestCase):
     def setUpClass(cls):
         global cl, pl
 
-        cl = ChannelLibrary(db_resource_name=":memory:")
+        cl = ChannelLibrary(":memory:")
         pl = PipelineManager()
 
     def _setUp(self, num_averages=50):

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -162,7 +162,7 @@ class WriteTestCase(unittest.TestCase):
             exp.run_sweeps()
             self.assertTrue(os.path.exists(tmpdirname+"/test_write-0000.auspex"))
             container = AuspexDataContainer(tmpdirname+"/test_write-0000.auspex")
-            data, desc = container.open_dataset('main', 'data')
+            data, desc, _ = container.open_dataset('main', 'data')
 
             self.assertTrue(0.0 not in data)
             self.assertTrue(np.all(desc['field'] == np.linspace(0,100.0,4)))
@@ -210,7 +210,7 @@ class WriteTestCase(unittest.TestCase):
 
             self.assertTrue(os.path.exists(tmpdirname+"/test_write_metadata-0000.auspex"))
             container = AuspexDataContainer(tmpdirname+"/test_write_metadata-0000.auspex")
-            data, desc = container.open_dataset('main', 'data')
+            data, desc, _ = container.open_dataset('main', 'data')
             
             self.assertTrue(0.0 not in data)
             self.assertTrue(np.all(desc['field'] == np.linspace(0,100.0,4)))
@@ -319,8 +319,8 @@ class WriteTestCase(unittest.TestCase):
             exp.run_sweeps()
 
             container = AuspexDataContainer(tmpdirname+"/test_write_samefile-0000.auspex")
-            data1, desc1 = container.open_dataset('group1', 'data')
-            data2, desc2 = container.open_dataset('group2', 'data')
+            data1, desc1, _ = container.open_dataset('group1', 'data')
+            data2, desc2, _ = container.open_dataset('group2', 'data')
             self.assertTrue(os.path.exists(tmpdirname+"/test_write_samefile-0000.auspex"))
             self.assertTrue(0.0 not in data1)
             self.assertTrue(0.0 not in data2)
@@ -348,7 +348,7 @@ class WriteTestCase(unittest.TestCase):
 
             self.assertTrue(os.path.exists(tmpdirname+"/test_write_complex-0000.auspex"))
             container = AuspexDataContainer(tmpdirname+"/test_write_complex-0000.auspex")
-            data, desc = container.open_dataset('main', 'data')
+            data, desc, _ = container.open_dataset('main', 'data')
 
             self.assertTrue(0.0 not in data)
             self.assertTrue(np.all(desc['field'] == np.linspace(0,100.0,4)))


### PR DESCRIPTION
Updated ChannelLibrary() declarations to avoid using resource_name keyword and now use mandatory positional argument for the database filename. 