### PR TITLE
Improvements to experiment error handling

### DIFF
--- a/src/auspex/experiment.py
+++ b/src/auspex/experiment.py
@@ -398,7 +398,7 @@ class Experiment(metaclass=MetaExperiment):
                             instr.disconnect()
                         except:
                             logger.error(f"Failed to disconnect from {instr.name}")
-                    pass
+                    raise Exception(f"Failed to connect to all instruments; disconnected as best as possible")
             self.instrs_connected = True
 
     def disconnect_instruments(self):
@@ -409,6 +409,7 @@ class Experiment(metaclass=MetaExperiment):
                     instrument.disconnect()
                 except:
                     logger.error(f"Failed to disconnect from {instrument.name}")
+                    #This probably should have a fail flag or something to throw a higher error after it's done trying to disconnect
             self.instrs_connected = False
 
     def init_dashboard(self):

--- a/src/auspex/experiment.py
+++ b/src/auspex/experiment.py
@@ -384,7 +384,7 @@ class Experiment(metaclass=MetaExperiment):
 
     def connect_instruments(self):
         # Connect the instruments to their resources
-        if not self.instrs_connected:
+        if self.instrs_connected == False:
             connected_list = []
             for instrument in self._instruments.values():
                 try:
@@ -394,7 +394,11 @@ class Experiment(metaclass=MetaExperiment):
                     logger.error(f"Failed to connect to instrument {instrument.name}")
                     logger.error("Disconnecting from other connected instruments")
                     for instr in connected_list:
-                        instr.disconnect()
+                        try:
+                            instr.disconnect()
+                        except:
+                            logger.error(f"Failed to disconnect from {instr.name}")
+                    pass
             self.instrs_connected = True
 
     def disconnect_instruments(self):

--- a/src/auspex/experiment.py
+++ b/src/auspex/experiment.py
@@ -385,14 +385,25 @@ class Experiment(metaclass=MetaExperiment):
     def connect_instruments(self):
         # Connect the instruments to their resources
         if not self.instrs_connected:
+            connected_list = []
             for instrument in self._instruments.values():
-                instrument.connect()
+                try:
+                    instrument.connect()
+                    connected_list.append(instrument)
+                except:
+                    logger.error(f"Failed to connect to instrument {instrument.name}")
+                    logger.error("Disconnecting from other connected instruments")
+                    for instr in connected_list:
+                        instr.disconnect()
             self.instrs_connected = True
 
     def disconnect_instruments(self):
         # Connect the instruments to their resources
         for instrument in self._instruments.values():
-            instrument.disconnect()
+            try:
+                instrument.disconnect()
+            except:
+                logger.error(f"Failed to disconnect from {instrument.name}")
         self.instrs_connected = False
 
     def init_dashboard(self):
@@ -549,6 +560,7 @@ class Experiment(metaclass=MetaExperiment):
         time.sleep(0.1)
         #connect all instruments
         self.connect_instruments()
+        assert self.instrs_connected == True, "Instruments were not connected successfully."
 
         try:
             #initialize instruments

--- a/src/auspex/experiment.py
+++ b/src/auspex/experiment.py
@@ -399,12 +399,13 @@ class Experiment(metaclass=MetaExperiment):
 
     def disconnect_instruments(self):
         # Connect the instruments to their resources
-        for instrument in self._instruments.values():
-            try:
-                instrument.disconnect()
-            except:
-                logger.error(f"Failed to disconnect from {instrument.name}")
-        self.instrs_connected = False
+        if self.instrs_connected == True:
+            for instrument in self._instruments.values():
+                try:
+                    instrument.disconnect()
+                except:
+                    logger.error(f"Failed to disconnect from {instrument.name}")
+            self.instrs_connected = False
 
     def init_dashboard(self):
         from bqplot import DateScale, LinearScale, DateScale, Axis, Lines, Figure, Tooltip

--- a/src/auspex/qubit/qubit_exp.py
+++ b/src/auspex/qubit/qubit_exp.py
@@ -567,26 +567,25 @@ class QubitExperiment(Experiment):
     def shutdown_instruments(self):
         # remove socket listeners
         logger.debug("Shutting down instruments")
-                try:
+        try:
             for awg in self.awgs:
                 try:
                     awg.stop()
                 except:
                     logger.error(f"Could not stop AWG {awg.name}")
-                    pass
+                    raise Exception(f"Could not stop AWG {awg.name}")
             for dig in self.digitizers:
                 try:
                     dig.stop()
                 except:
                     logger.error(f"Could not stop digitizer {dig.name}")
-                    pass
+                    raise Exception(f"Could not stop digitizer {dig.name}")
             for gen_proxy in self.generators:
-                # print("Not shutting down generators! WARNING!")
                 try:
                     gen_proxy.instr.output = False
                 except:
                     logger.error(f"Could not set {gen_proxy.name} output to false")
-                    pass
+                    raise Exception(f"Could not set {gen_proxy.name} output to false")
         except:
             logger.error('Could Not Stop AWGs or Digitizers; Reset Experiment') 
         failflag = False

--- a/src/auspex/qubit/qubit_exp.py
+++ b/src/auspex/qubit/qubit_exp.py
@@ -598,13 +598,16 @@ class QubitExperiment(Experiment):
                 failflag = True
         if failflag is True:
             logger.error('Could not disconnect from some number of instruments, they may need to be reset.')
-        self.dig_exit.set() #This fails raising AttributeError sometimes, if it happens to others should also set this more carefully
-        for listener in self.dig_listeners:
-            listener.join(2)
-            if listener.is_alive():
-                logger.debug(f"Terminating listener {listener} aggressively")
-                listener.terminate()
-            del listener
+        
+        #Ensure that the digitizer-related attributes were created, since they aren't in certain failure conditions.
+        if hasattr(self,"dig_exit") and hasattr(self, "dig_listeners"):
+            self.dig_exit.set()
+            for listener in self.dig_listeners:
+                listener.join(2)
+                if listener.is_alive():
+                    logger.debug(f"Terminating listener {listener} aggressively")
+                    listener.terminate()
+                del listener
 
         import gc
         gc.collect()


### PR DESCRIPTION
This is focused on experiment.py and qubit_exp.py, other specialized experiments may need to have similar changes made to match the behavior.
Some key changes:
-If one instrument fails to connect, disconnect from all previously connected instruments
-Report which instrument failed to connect/disconnect
-Check that listeners/dig_exit exist before trying to modify them in shutdown code