### PR TITLE
Removed reference to slepian function in integrator.py

### DIFF
--- a/src/auspex/filters/integrator.py
+++ b/src/auspex/filters/integrator.py
@@ -10,7 +10,7 @@ __all__ = ['KernelIntegrator']
 
 import os
 import numpy as np
-from scipy.signal import chebwin, blackman, slepian, convolve
+from scipy.signal import chebwin, blackman, convolve
 
 from .filter import Filter
 from auspex.parameter import Parameter, FloatParameter, IntParameter, BoolParameter


### PR DESCRIPTION
Slepian function in scipy has been deprecated, but it was still being imported in integrator.py. Luckily it was imported but never used!