### PR TITLE
WIP: Feature/self aware filters

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ install_requires = [
     "ipywidgets >= 7.0.0",
     "sqlalchemy >= 1.2.15",
     "pyserial >= 3.4",
-    "multiprocess == 0.70.11.1"
+    "multiprocess == 0.70.11.1",
     "setproctitle",
     "progress"
 ]

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ install_requires = [
     "ipywidgets >= 7.0.0",
     "sqlalchemy >= 1.2.15",
     "pyserial >= 3.4",
+    "multiprocess == 0.70.11.1"
     "setproctitle",
     "progress"
 ]

--- a/src/auspex/experiment.py
+++ b/src/auspex/experiment.py
@@ -10,6 +10,7 @@ import os
 import sys
 import uuid
 import json
+import traceback
 
 from auspex.log import logger
 
@@ -179,6 +180,9 @@ class Experiment(metaclass=MetaExperiment):
 
         # Should we show the dashboard?
         self.dashboard = False
+
+        # Profile?
+        self.profile = False
 
         # Multiprocessing manager?
         self.manager = mp.Manager()
@@ -814,13 +818,13 @@ class Experiment(metaclass=MetaExperiment):
                         logger.info("Connection established to plot server.")
                         self.do_plotting = True
                     else:
-                        raise Exception("Server returned invalid message, expected ACK.")
+                        raise Exception("Plot server returned invalid message, expected ACK.")
                 except:
-                    logger.info("Could not connect to server.")
+                    logger.info("Could not connect to plot server.")
                     for p in self.plotters:
                         p.do_plotting = False
             else:
-                logger.info("Plot Server did not respond.")
+                logger.info("Plot server did not respond.")
                 for p in self.plotters:
                     p.do_plotting = False
 

--- a/src/auspex/experiment.py
+++ b/src/auspex/experiment.py
@@ -11,16 +11,24 @@ import sys
 import uuid
 import json
 
-if sys.platform == 'win32' or 'NOFORKING' in os.environ:
-    from queue import Queue as Queue
-    from threading import Event
-    from threading import Thread as Process
-    from threading import Thread as Thread
-else:
-    from multiprocessing import Queue as Queue
-    from multiprocessing import Event
-    from multiprocessing import Process
-    from threading import Thread as Thread
+from auspex.log import logger
+
+# if sys.platform == 'win32' or 'NOFORKING' in os.environ:
+#     logger.info("Using threads")
+#     from queue import Queue as Queue
+#     from threading import Event
+#     from threading import Thread as Process
+#     from threading import Thread as Thread
+# else:
+
+from multiprocess import Queue as Queue
+from multiprocess import Event
+from multiprocess import Process
+import multiprocess as mp
+from threading import Thread as Thread
+import multiprocess.context as ctx
+# ctx._force_start_method('fork')
+logger.info(f"Using pathos multiprocess with {mp.get_start_method()}")
 
 from IPython.core.getipython import get_ipython
 in_notebook = False
@@ -53,7 +61,7 @@ from auspex.parameter import ParameterGroup, FloatParameter, IntParameter, Param
 from auspex.sweep import Sweeper
 from auspex.stream import DataStream, DataAxis, SweepAxis, DataStreamDescriptor, InputConnector, OutputConnector
 from auspex.filters import Plotter, MeshPlotter, ManualPlotter, WriteToFile, DataBuffer, Filter
-from auspex.log import logger
+
 import auspex.config
 from auspex.config import isnotebook
 
@@ -85,9 +93,10 @@ def update_filename(filename, add_date=True):
     return "{}-{:04d}".format(basename,i)
 
 class ExperimentGraph(object):
-    def __init__(self, edges):
+    def __init__(self, edges, manager):
         self.dag = None
         self.edges = []
+        self.manager = manager
         self.create_graph(edges)
 
     def dfs_edges(self):
@@ -110,7 +119,8 @@ class ExperimentGraph(object):
         dag = nx.DiGraph()
         self.edges = []
         for edge in edges:
-            obj = DataStream(name="{}_TO_{}".format(edge[0].name, edge[1].name))
+            logger.debug(f"{edge[0].name}_TO_{edge[1].name}:  {self.manager}")
+            obj = DataStream(name="{}_TO_{}".format(edge[0].name, edge[1].name), manager=self.manager)
             edge[0].add_output_stream(obj)
             edge[1].add_input_stream(obj)
             self.edges.append(obj)
@@ -169,6 +179,9 @@ class Experiment(metaclass=MetaExperiment):
 
         # Should we show the dashboard?
         self.dashboard = False
+
+        # Multiprocessing manager?
+        self.manager = mp.Manager()
 
         # Create and use plots?
         self.do_plotting = False
@@ -246,6 +259,12 @@ class Experiment(metaclass=MetaExperiment):
         # Run the stream init
         self.init_streams()
 
+        # Event for filters to register a panic
+        self.filter_panic = Event()
+
+        # Event to tell all filters to exit
+        self.filter_exit  = Event()
+
     def set_graph(self, edges):
         unique_nodes = []
         for eb, ee in edges:
@@ -254,7 +273,7 @@ class Experiment(metaclass=MetaExperiment):
             if ee.parent not in unique_nodes:
                 unique_nodes.append(ee.parent)
         self.nodes = unique_nodes
-        self.graph = ExperimentGraph(edges)
+        self.graph = ExperimentGraph(edges, manager=self.manager)
 
     def init_streams(self):
         """Establish the base descriptors for any internal data streams and connectors."""
@@ -371,6 +390,12 @@ class Experiment(metaclass=MetaExperiment):
 
             # Run the procedure
             self.run()
+
+            # Check for any filter panics
+            if self.filter_panic.is_set():
+                logger.warning("Panic detected in listeners/filters. Exiting.")
+                self.filter_exit.set()
+                break
 
             # See if the axes want to extend themselves. They will push updates
             # directly to the output_connecters as messages that will be passed
@@ -573,23 +598,15 @@ class Experiment(metaclass=MetaExperiment):
             #initialize instruments
             self.init_instruments()
 
-            # def catch_ctrl_c(signum, frame):
-            #     import ipdb; ipdb.set_trace();
-            #     logger.info("Caught SIGINT. Shutting down.")
-            #     self.declare_done() # Ask nicely
-
-            #     self.shutdown()
-            #     raise NameError("Shutting down.")
-            #     sys.exit(0)
-
-            # signal.signal(signal.SIGINT, catch_ctrl_c)
-
             # We want to wait for the sweep method above,
             # not the experiment's run method, so replace this
             # in the list of tasks.
             self.other_nodes = self.nodes[:]
             self.other_nodes.extend(self.extra_plotters)
             self.other_nodes.remove(self)
+            self.other_node_processes = {}
+            self.other_node_configs = {}
+            self.other_node_outputs = {}
 
             # If we are launching the process dashboard,
             # setup the bokeh server and establish a queue for
@@ -601,7 +618,15 @@ class Experiment(metaclass=MetaExperiment):
 
             # Start the filter processes
             for n in self.other_nodes:
-                n.start()
+                conf = n.get_config()
+                oq = Queue()
+                p = Process(target=n.run, args=(conf, self.filter_exit, n.done, self.filter_panic,
+                                                 n.output_connectors, n.input_connectors, 
+                                                 self.profile, n.perf_queue, oq))
+                p.start()
+                self.other_node_configs[n] = conf 
+                self.other_node_processes[n] = p
+                self.other_node_outputs[n] = oq
 
             # Run the main experiment loop
             self.sweep()
@@ -611,7 +636,7 @@ class Experiment(metaclass=MetaExperiment):
                 if callback:
                     callback(plot)
 
-            # Wait for the
+            # Wait for the filters to finish.
             time.sleep(0.1)
             times = {n: 0 for n in self.other_nodes}
             dones = {n: n.done.is_set() for n in self.other_nodes}
@@ -630,7 +655,19 @@ class Experiment(metaclass=MetaExperiment):
                     n.final_buffer = n._final_buffer.get()
 
             for n in self.other_nodes:
-                n.join()
+                p = self.other_node_processes[n]
+                conf = self.other_node_configs[n]
+                oq = self.other_node_outputs[n]
+                
+                while True:
+                    try:
+                        # Get the Output Queue
+                        param, v = oq.get(False)
+                        setattr(n, param, v)
+                    except:
+                        break
+
+                p.join()
 
             for buff in self.buffers:
                 buff.output_data, buff.descriptor = buff.get_data()
@@ -640,9 +677,11 @@ class Experiment(metaclass=MetaExperiment):
                 self.perf_thread.join()
 
         except KeyboardInterrupt as e:
-            print("Caught KeyboardInterrupt, terminating.")
-            #self.shutdown() #Commented out, since this is already in the finally.
-            #sys.exit(0)
+            logger.warning("Caught KeyboardInterrupt, shutting down.")
+        except Exception as e:
+            just_the_string = traceback.format_exc()
+            logger.warning(f"Experiment raised exception {e} (traceback follows). Bailing.")
+            logger.warning(just_the_string)
         finally:
             self.shutdown()
 
@@ -655,7 +694,6 @@ class Experiment(metaclass=MetaExperiment):
             mp.stop()
 
     def shutdown(self):
-        logger.debug("Shutting down instruments")
         # This includes stopping the flow of data, and must be done before terminating nodes
         self.shutdown_instruments()
 
@@ -663,7 +701,7 @@ class Experiment(metaclass=MetaExperiment):
             ct_max = 5 #arbitrary waiting 10 s before giving up
             for ct in range(ct_max):
                 if hasattr(self, 'other_nodes'):
-                    if any([n.is_alive() for n in self.other_nodes]):
+                    if any([p.is_alive() for p in self.other_node_processes.values()]):
                         logger.warning("Filter pipeline appears stuck. Use keyboard interrupt to terminate.")
                         time.sleep(2.0)
                     else:

--- a/src/auspex/filters/channelizer.py
+++ b/src/auspex/filters/channelizer.py
@@ -68,7 +68,7 @@ class Channelizer(Filter):
             self.follow_axis.value = follow_axis
         if follow_freq_offset:
             self.follow_freq_offset.value = follow_freq_offset
-        self.quince_parameters = [self.decimation_factor, self.frequency, self.bandwidth]
+        # self.quince_parameters = [self.decimation_factor, self.frequency, self.bandwidth]
         self._phase = 0.0
 
     def final_init(self):

--- a/src/auspex/filters/elementwise.py
+++ b/src/auspex/filters/elementwise.py
@@ -31,7 +31,7 @@ class ElementwiseFilter(Filter):
     def __init__(self, filter_name=None, **kwargs):
         super(ElementwiseFilter, self).__init__(filter_name=filter_name, **kwargs)
         self.sink.max_input_streams = 100
-        self.quince_parameters = []
+        # self.quince_parameters = []
 
     def operation(self):
         """Must be overridden with the desired mathematical function"""

--- a/src/auspex/filters/framer.py
+++ b/src/auspex/filters/framer.py
@@ -32,7 +32,7 @@ class Framer(Filter):
         self.sum_so_far = None
         self.num_averages = None
 
-        self.quince_parameters = [self.axis]
+        # self.quince_parameters = [self.axis]
 
     def final_init(self):
         descriptor_in = self.sink.descriptor

--- a/src/auspex/filters/io.py
+++ b/src/auspex/filters/io.py
@@ -17,11 +17,9 @@ if sys.platform == 'win32' or 'NOFORKING' in os.environ:
     from threading import Event
     from queue import Queue
 else:
-    import multiprocessing as mp
-    from multiprocessing import Process, Event
-    from multiprocessing import Queue
-
-from auspex.data_format import AuspexDataContainer
+    import multiprocess as mp
+    from multiprocess import Process, Event
+    from multiprocess import Queue
 
 import itertools
 import contextlib
@@ -35,10 +33,11 @@ from shutil import copyfile
 import cProfile
 
 from .filter import Filter
+from auspex.data_format import AuspexDataContainer
 from auspex.parameter import Parameter, FilenameParameter, BoolParameter
 from auspex.stream import InputConnector, OutputConnector
-from auspex.log import logger
 import auspex.config as config
+from auspex.log import logger
 
 class WriteToFile(Filter):
     """Writes data to file using the Auspex container type, which is a simple directory structure
@@ -65,14 +64,24 @@ class WriteToFile(Filter):
         assert self.filename.value, "Filename never supplied to writer."
         assert self.groupname.value, "Groupname never supplied to writer."
         assert self.datasetname.value, "Dataset name never supplied to writer."
-
         self.descriptor = self.sink.input_streams[0].descriptor
-        self.container  = AuspexDataContainer(self.filename.value)
-        self.group      = self.container.new_group(self.groupname.value)
-        self.mmap       = self.container.new_dataset(self.groupname.value, self.datasetname.value, self.descriptor)
 
-        self.w_idx = 0
-        self.points_taken = 0
+    def get_config(self):
+        config = super().get_config()
+        config['dtype']            = self.descriptor.dtype
+        config['w_idx']            = 0
+        config['points_taken']     = 0
+        config['descriptor']       = self.descriptor
+        config['filename']         = self.filename.value
+        config['groupname']        = self.groupname.value
+        config['datasetname']      = self.datasetname.value
+        return config
+
+    @classmethod
+    def execute_on_run(cls, config):
+        config['container']  = AuspexDataContainer(config['filename'])
+        config['group']      = config['container'].new_group(config['groupname'])
+        config['mmap']       = config['container'].new_dataset(config['groupname'], config['datasetname'], config['descriptor'])
 
     def get_data_while_running(self, return_queue):
         """Return data to the main thread or user as requested. Use a MP queue to transmit."""
@@ -82,13 +91,14 @@ class WriteToFile(Filter):
     def get_data(self):
         assert self.done.is_set(), Exception("Experiment is still running. Please use get_data_while_running")
         container = AuspexDataContainer(self.filename.value)
-        return container.open_dataset(self.groupname.value, self.datasetname.value)
+        return container.open_dataset(self.groupname.value, self.datasetname.value)[:2]
 
-    def process_data(self, data):
+    @classmethod
+    def process_data(cls, config, ocs, ics, data):
         # Write the data
-        self.mmap[self.w_idx:self.w_idx+data.size] = data
-        self.w_idx += data.size
-        self.points_taken = self.w_idx
+        config['mmap'][config['w_idx']:config['w_idx']+data.size] = data
+        config['w_idx'] += data.size
+        config['points_taken'] = config['w_idx']
 
 class DataBuffer(Filter):
     """Writes data to IO."""
@@ -97,31 +107,49 @@ class DataBuffer(Filter):
 
     def __init__(self, **kwargs):
         super(DataBuffer, self).__init__(**kwargs)
-        self._final_buffer = Queue()
-        self._temp_buffer = Queue()
+        if self.manager:
+            self._final_buffer = self.manager.Queue()
+            self._temp_buffer = self.manager.Queue()
+        else:
+            self._final_buffer = Queue()
+            self._temp_buffer = Queue()
         self._get_buffer = Event()
         self.final_buffer  = None
 
     def final_init(self):
-        self.w_idx        = 0
-        self.points_taken = 0
         self.descriptor   = self.sink.input_streams[0].descriptor
-        self.buff         = np.empty(self.descriptor.expected_num_points(), dtype=self.descriptor.dtype)
 
-    def checkin(self):
-        if self._get_buffer.is_set():
-            self._temp_buffer.put(self.buff)
-        self._get_buffer.clear()
+    def get_config(self):
+        config = super().get_config()
+        config['dtype']            = self.descriptor.dtype
+        config['w_idx']            = 0
+        config['points_taken']     = 0
+        config['expected_points']  = self.descriptor.expected_num_points()
+        config['final_buffer']     = self._final_buffer
+        config['temp_buffer']      = self._temp_buffer
+        config['get_buffer']       = self._get_buffer
+        return config
 
-    def process_data(self, data):
+    @classmethod
+    def execute_on_run(cls, config):
+        config['buff'] = np.empty(config['expected_points'], dtype=config['dtype'])
+
+    @classmethod
+    def execute_after_run(cls, config, output_queue):
+        if mp.get_start_method() == "spawn":
+            output_queue.put(("_final_buffer", config['buff']))
+        config['final_buffer'].put(config['buff'])
+
+    @classmethod
+    def process_data(cls, config, ocs, ics, data):
         # Write the data
-        self.buff[self.w_idx:self.w_idx+data.size] = data
-        self.w_idx += data.size
-        self.points_taken = self.w_idx
+        config['buff'][config['w_idx']:config['w_idx']+data.size] = data
+        config['w_idx'] += data.size
+        config['points_taken'] = config['w_idx']
 
-    def main(self):
-        super(DataBuffer, self).main()
-        self._final_buffer.put(self.buff)
+        if config['get_buffer'].is_set():
+            config['temp_buffer'].put(config['buff'])
+            config['get_buffer'].clear()
 
     def get_data(self):
         if self.done.is_set():

--- a/src/auspex/filters/plot.py
+++ b/src/auspex/filters/plot.py
@@ -24,8 +24,8 @@ if sys.platform == 'win32' or 'NOFORKING' in os.environ:
     import threading as mp
     from queue import Queue
 else:
-    import multiprocessing as mp
-    from multiprocessing import Queue
+    import multiprocess as mp
+    from multiprocess import Queue
 
 class Plotter(Filter):
     sink      = InputConnector()

--- a/src/auspex/filters/plot.py
+++ b/src/auspex/filters/plot.py
@@ -47,7 +47,7 @@ class Plotter(Filter):
         self._final_buffer = Queue()
         self.final_buffer = None
 
-        self.quince_parameters = [self.plot_dims, self.plot_mode]
+        # self.quince_parameters = [self.plot_dims, self.plot_mode]
 
         # Unique id for plot server
         self.uuid = None

--- a/src/auspex/filters/singleshot.py
+++ b/src/auspex/filters/singleshot.py
@@ -53,8 +53,8 @@ class SingleShotMeasurement(Filter):
             self.set_threshold.value = set_threshold
             self.logistic_regression.value = logistic_regression
 
-        self.quince_parameters = [self.save_kernel, self.optimal_integration_time,
-            self.zero_mean, self.set_threshold, self.logistic_regression]
+        # self.quince_parameters = [self.save_kernel, self.optimal_integration_time,
+            # self.zero_mean, self.set_threshold, self.logistic_regression]
 
         self.pdf_data_queue = Queue() #Output queue
         self.fidelity       = self.source

--- a/src/auspex/filters/singleshot.py
+++ b/src/auspex/filters/singleshot.py
@@ -20,7 +20,7 @@ import sys
 if sys.platform == 'win32' or 'NOFORKING' in os.environ:
     from queue import Queue
 else:
-    from multiprocessing import Queue
+    from multiprocess import Queue
 
 from .filter import Filter
 from auspex.parameter import Parameter, FloatParameter, IntParameter, BoolParameter

--- a/src/auspex/instruments/alazar.py
+++ b/src/auspex/instruments/alazar.py
@@ -15,7 +15,7 @@ import datetime, time
 import sys
 import numpy as np
 
-from multiprocessing import Value
+from multiprocess import Value
 
 from .instrument import Instrument, ReceiverChannel
 from auspex.log import logger

--- a/src/auspex/instruments/stanford.py
+++ b/src/auspex/instruments/stanford.py
@@ -86,7 +86,7 @@ class SR830(SCPIInstrument):
         self.interface.write("TRCB?{:d},0,{:d}".format(channel, stored_points))
         #buf = self.interface.read_raw(numbytes=4)
         buf = self.interface.read_bytes(4*stored_points,chunk_size=4)
-        logger.info(f"Raw buffer is {buf} with length {len(buf)} bytes.")
+        # logger.info(f"Raw buffer is {buf} with length {len(buf)} bytes.")
         return np.frombuffer(buf, dtype=np.float32)
 
     def buffer_start(self):

--- a/test/test_alazar.py
+++ b/test/test_alazar.py
@@ -1,4 +1,4 @@
-from multiprocessing import Queue, Process, Event, Value
+from multiprocess import Queue, Process, Event, Value
 from auspex.instruments import AlazarATS9870, AlazarChannel
 
 import time


### PR DESCRIPTION
Yikes.

Trying to solve a few problems here:
1. **Improved pipeline stability** - @martin-gustafsson identified a lot of sketchy behavior of the pipeline. I moved to having all of the filer objects sharing `Exit` and now `Panic` events that the filter set upon Exceptions and the experiment periodically checks to see if it should bail. I have no real-world stability improvements to claim.
2. **Move to methods running actual filter code** - using class methods allows Processes to be started without any explicit dependence on instance variables. Verbosity increases here since we now have to explicitly pass lots of important constructs, but in principle it is now much easier to write a fast filter in some external language. Currently configuration parameters live in a dictionary, but this could be spit out in ctypes struct later on.
3. **Finally allow things to work using spawn** - this is a disaster as references to shared objects such as Queues and RawArrays are not properly synchronized without a multiprocessing Manager entity. Adding this still took a TON of hacks to fix numpy RawArray mappers, return values from IO buffers, etc. etc. etc. Using vanilla multiprocessing is 

Still need to convert the following to using class methods:
- [ ] Alazar listener
- [ ] Filters other than averager and buffer