### PR TITLE
WIP: Parametric Sweeps and DataContainer improvements

### DIFF
--- a/src/auspex/data_format.py
+++ b/src/auspex/data_format.py
@@ -94,14 +94,7 @@ class AuspexDataContainer(object):
         filename = os.path.join(self.base_path,groupname,datasetname+'_meta.json')
         assert not os.path.exists(filename), "Existing dataset metafile found. Did you want to open instead?"
         meta = {'shape': tuple(descriptor.dims()), 'dtype': np.dtype(descriptor.dtype).str}
-        meta['axes'] = {a.name: a.points.tolist() for a in descriptor.axes}
-        meta['units'] = {a.name: a.unit for a in descriptor.axes}
-        meta['meta_data'] = {}
-        for a in descriptor.axes:
-            if a.metadata is not None:
-                meta['meta_data'][a.name] = a.metadata
-            else:
-                meta['meta_data'][a.name] = None
+        meta['axes'] = [{'name': a.name, 'unit': a.unit, 'points': a.points.tolist(), 'metadata': a.metadata} for a in descriptor.axes]
         meta['filename'] = os.path.join(self.base_path,groupname,datasetname)
         with open(filename, 'w') as f:
             json.dump(meta, f)
@@ -164,8 +157,8 @@ class AuspexDataContainer(object):
         del mm
 
         desc = DataStreamDescriptor(meta['dtype'])
-        for name, points in meta['axes'].items():
-            ax = DataAxis(name, points, unit=meta['units'][name])
-            ax.metadata = meta['meta_data'][name]
+        for a in meta['axes'][::-1]:
+            ax = DataAxis(a['name'], a['points'], unit=a['unit'])
+            ax.metadata = a['metadata']
             desc.add_axis(ax)
         return data, desc, self.base_path.replace('.auspex', '')

--- a/src/auspex/data_format.py
+++ b/src/auspex/data_format.py
@@ -10,6 +10,9 @@ from .stream import DataStreamDescriptor, DataAxis
 import numpy as np
 import os, os.path
 import json
+import datetime
+
+AUSPEX_CONTAINER_VERSION = 1.1
 
 class AuspexDataContainer(object):
     """A container for Auspex data. Data is stored as `datasets` which may be of any dimension. These are in turn
@@ -27,7 +30,7 @@ class AuspexDataContainer(object):
                         | - DemodulatedData
     """
 
-    def __init__(self, base_path, mode='a', open_all=True):
+    def __init__(self, base_path, mode='a', open_all=True, metadata=None):
         """Initialize the data container.
 
         Args:
@@ -40,7 +43,8 @@ class AuspexDataContainer(object):
         self.open_mmaps = []
         self.mode = mode
         self._create()
-        
+        self.metadata = metadata
+
         if open_all:
             self.open_all()
 
@@ -57,6 +61,22 @@ class AuspexDataContainer(object):
             assert not os.path.exists(self.base_path), "Existing data container found. Did you want to open instead?"
         os.makedirs(self.base_path, exist_ok=True)
         self.groups = {}
+
+    @property
+    def metadata(self):
+        filename = os.path.join(self.base_path,'meta.json')
+        assert os.path.exists(filename), "Container metadata does not exist, this must be an old .auspex file that is no longer supported."
+        with open(filename, 'r') as f:
+            a = json.load(f)
+        a['date'] = datetime.datetime.strptime(a['date'], '%Y-%m-%d %H:%M:%S.%f')
+        return a
+
+    @metadata.setter
+    def metadata(self, value):
+        filename = os.path.join(self.base_path,'meta.json')
+        meta = {'version': AUSPEX_CONTAINER_VERSION, 'date': str(datetime.datetime.now()), 'metadata': value}
+        with open(filename, 'w') as f:
+            json.dump(meta, f)
 
     def new_group(self, groupname):
         """Add a group to the data container.
@@ -125,14 +145,16 @@ class AuspexDataContainer(object):
         """
         ret = {}
         for groupname in os.listdir(self.base_path):
-            ret[groupname] = {}
-            self.groups[groupname] = {}
-            for datasetname in os.listdir(os.path.join(self.base_path,groupname)):
-                if datasetname[-4:] == '.dat':
-                    dat = self.open_dataset(groupname, datasetname[:-4])
-                    self.groups[groupname][datasetname[:-4]] = dat
-                    ret[groupname][datasetname[:-4]] = dat
+            if os.path.isdir(os.path.join(self.base_path,groupname)):
+                ret[groupname] = {}
+                self.groups[groupname] = {}
+                for datasetname in os.listdir(os.path.join(self.base_path,groupname)):
+                    if datasetname[-4:] == '.dat':
+                        dat = self.open_dataset(groupname, datasetname[:-4])
+                        self.groups[groupname][datasetname[:-4]] = dat
+                        ret[groupname][datasetname[:-4]] = dat
         return ret
+
     def open_dataset(self, groupname, datasetname):
         """Open a particular dataset stored in this DataContainer.
 

--- a/src/auspex/experiment.py
+++ b/src/auspex/experiment.py
@@ -372,11 +372,6 @@ class Experiment(metaclass=MetaExperiment):
             # Run the procedure
             self.run()
 
-            # See if the axes want to extend themselves. They will push updates
-            # directly to the output_connecters as messages that will be passed
-            # through the filter pipeline.
-            self.sweeper.check_for_refinement(self.output_connectors)
-
             # Finish up, checking to see whether we've received all of our data
             if self.sweeper.done():
                 self.declare_done()
@@ -670,8 +665,8 @@ class Experiment(metaclass=MetaExperiment):
             logger.debug("Adding axis %s to connector %s.", axis, oc.name)
             oc.descriptor.add_axis(axis, position=position)
 
-    def add_sweep(self, parameters, sweep_list, refine_func=None, callback_func=None, metadata=None):
-        ax = SweepAxis(parameters, sweep_list, refine_func=refine_func, callback_func=callback_func, metadata=metadata)
+    def add_sweep(self, parameters, sweep_list, callback_func=None, metadata=None):
+        ax = SweepAxis(parameters, sweep_list, callback_func=callback_func, metadata=metadata)
         ax.experiment = self
         self.sweeper.add_sweep(ax)
         self.add_axis(ax)

--- a/src/auspex/experiment.py
+++ b/src/auspex/experiment.py
@@ -350,25 +350,6 @@ class Experiment(metaclass=MetaExperiment):
                         else:
                             self.progressbars[axis].goto(axis.step)
 
-            if self.sweeper.is_adaptive():
-                # Add the new tuples to the stream descriptors
-                for oc in self.output_connectors.values():
-                    # Obtain the lists of values for any fixed
-                    # DataAxes and append them to them to the sweep_values
-                    # in preperation for finding all combinations.
-                    vals = [a for a in oc.descriptor.data_axis_values()]
-                    if sweep_values:
-                        vals  = [[v] for v in sweep_values] + vals
-                    # Find all coordinate tuples and update the list of
-                    # tuples that the experiment has probed.
-                    nested_list    = list(itertools.product(*vals))
-                    flattened_list = [tuple((val for sublist in line for val in sublist)) for line in nested_list]
-                    oc.descriptor.visited_tuples = oc.descriptor.visited_tuples + flattened_list
-
-                    # Since the filters are in separate processes, pass them the same
-                    # information so that they may perform the same operations.
-                    oc.push_event("new_tuples", (axis_names, sweep_values,))
-
             # Run the procedure
             self.run()
 

--- a/src/auspex/filters/elementwise.py
+++ b/src/auspex/filters/elementwise.py
@@ -97,8 +97,6 @@ class ElementwiseFilter(Filter):
                     if message_type == 'event':
                         if message['event_type'] == 'done':
                             streams_done[stream] = True
-                        elif message['event_type'] == 'refine':
-                            logger.warning("ElementwiseFilter doesn't handle refinement yet!")
                     elif message_type == 'data':
                         # Add any old data...
                         message_data = stream.pop()

--- a/src/auspex/filters/filter.py
+++ b/src/auspex/filters/filter.py
@@ -234,7 +234,7 @@ class Filter(Process, metaclass=MetaFilter):
             for message in messages:
                 message_type = message['type']
                 if message['type'] == 'event':
-                    logger.debug('%s "%s" received event with type "%s"', self.__class__.__name__, message_type)
+                    logger.debug('%s received event with type "%s"', self.__class__.__name__, message_type)
 
                     # Check to see if we're done
                     if message['event_type'] == 'done':

--- a/src/auspex/filters/integrator.py
+++ b/src/auspex/filters/integrator.py
@@ -10,7 +10,7 @@ __all__ = ['KernelIntegrator']
 
 import os
 import numpy as np
-from scipy.signal import chebwin, blackman, slepian, convolve
+from scipy.signal import chebwin, blackman, convolve
 
 from .filter import Filter
 from auspex.parameter import Parameter, FloatParameter, IntParameter, BoolParameter

--- a/src/auspex/filters/io.py
+++ b/src/auspex/filters/io.py
@@ -50,7 +50,7 @@ class WriteToFile(Filter):
     groupname   = Parameter(default='main')
     datasetname = Parameter(default='data')
 
-    def __init__(self, filename=None, groupname=None, datasetname=None, **kwargs):
+    def __init__(self, filename=None, groupname=None, datasetname=None, metadata=None, **kwargs):
         super(WriteToFile, self).__init__(**kwargs)
         if filename: 
             self.filename.value = filename
@@ -59,6 +59,7 @@ class WriteToFile(Filter):
         if datasetname:
             self.datasetname.value = datasetname
 
+        self.metadata = metadata
         self.ret_queue = None # MP queue For returning data
 
     def final_init(self):
@@ -67,7 +68,7 @@ class WriteToFile(Filter):
         assert self.datasetname.value, "Dataset name never supplied to writer."
 
         self.descriptor = self.sink.input_streams[0].descriptor
-        self.container  = AuspexDataContainer(self.filename.value)
+        self.container  = AuspexDataContainer(self.filename.value, metadata=self.metadata)
         self.group      = self.container.new_group(self.groupname.value)
         self.mmap       = self.container.new_dataset(self.groupname.value, self.datasetname.value, self.descriptor)
 

--- a/src/auspex/qubit/pulse_calibration.py
+++ b/src/auspex/qubit/pulse_calibration.py
@@ -16,7 +16,6 @@ except:
 import auspex.config as config
 from auspex.log import logger
 from copy import copy, deepcopy
-# from adapt.refine import refine_1D
 import os
 import uuid
 import pandas as pd
@@ -382,9 +381,7 @@ class CavityTuneup(QubitCalibration):
         self.frequencies = np.empty(0, dtype=np.complex128)
         self.group_delays = np.empty(0, dtype=np.complex128)
         self.datas = np.empty(0, dtype=np.complex128)
-        # orig_avg = self.kwargs['averages']
-        # Adaptive refinement to find cavity feature
-        # for i in range(self.iterations + 1):
+
         self.data, _      = self.run_sweeps()
         self.datas        = np.append(self.datas, self.data)
         self.frequencies  = np.append(self.frequencies, self.new_frequencies[:-1])
@@ -466,58 +463,6 @@ class CavityTuneup(QubitCalibration):
 
         shifted_cav = np.real(self.datas) - np.mean(np.real(self.datas))
         guess = np.abs(self.frequencies[np.argmax(np.abs(shifted_cav))])
-            # self.kwargs['averages'] = 2000
-
-            # import pdb; pdb.set_trace()
-            #
-            # self.new_frequencies = refine_1D(self.frequencies, subtracted, all_points=False,
-            #                             criterion="difference", threshold = "one_sigma")
-            # logger.info(f"new_frequencies {self.new_frequencies}")
-
-        # n, bins = sp.histogram(np.abs(self.frequencies), bins="auto")
-        # f_start = bins[np.argmax(n)]
-        # f_stop  = bins[np.argmax(n)+1]
-        # logger.info(f"Looking in bin from {f_start} to {f_stop}")
-
-        # # self.kwargs['averages'] = orig_avg
-        # self.new_frequencies = np.arange(f_start, f_stop, 2e6)
-        # self.frequencies = np.empty(0, dtype=np.complex128)
-        # self.group_delays = np.empty(0, dtype=np.complex128)
-        # self.datas = np.empty(0, dtype=np.complex128)
-        #
-        # for i in range(self.iterations + 3):
-        #     self.data, _      = self.run_sweeps()
-        #     self.datas        = np.append(self.datas, self.data)
-        #     self.frequencies  = np.append(self.frequencies, self.new_frequencies[:-1])
-        #
-        #     ord = np.argsort(self.frequencies)
-        #     self.datas = self.datas[ord]
-        #     self.frequencies = self.frequencies[ord]
-        #
-        #     self.group_delays = -np.diff(np.unwrap(np.angle(self.datas)))/np.diff(self.frequencies)
-        #     # self.group_delays = group_del
-        #
-        #     # ordering = np.argsort(self.frequencies[:-1])
-        #     self.plot3["Group Delay"] = (self.frequencies[1:],self.group_delays)
-        #     # self.plot2["Amplitude"] = (self.frequencies,np.abs(self.datas))
-        #     # self.kwargs['averages'] = 2000
-        #
-        #     self.new_frequencies = refine_1D(self.frequencies[:-1], self.group_delays, all_points=False,
-        #                                 criterion="integral", threshold = "one_sigma")
-        #     logger.info(f"new_frequencies {self.new_frequencies}")
-        # #
-
-        # # self.data, _ = self.run_sweeps()
-        # # group_delay = -np.diff(np.unwrap(np.angle(self.data)))/np.diff(self.new_frequencies)
-        # # self.plot3["Group Delay"] = (self.new_frequencies[1:],group_delay)
-        #
-        # def lor_der(x, a, x0, width, offset):
-        #     return offset-(x-x0)*a/((4.0*((x-x0)/width)**2 + a**2)**2)
-        # f0 = np.abs(self.frequencies[np.argmax(np.abs(self.group_delays))])
-        # p0 = [np.max(np.abs(self.group_delays))*1e-18, np.abs(f0), 200e6, np.abs(self.group_delays)[0]]
-        # popt, pcov = curve_fit(lor_der, np.abs(self.frequencies[1:]), np.abs(self.group_delays), p0=p0)
-        # self.plot3["Group Delay Fit"] = ( np.abs(self.frequencies[1:]),  lor_der( np.abs(self.frequencies[1:]), *popt))
-
 
     def init_plots(self):
         plot1 = ManualPlotter("Phase", x_label='Frequency (GHz)', y_label='Group Delay')
@@ -531,14 +476,11 @@ class CavityTuneup(QubitCalibration):
         plot2 = ManualPlotter("Amplitude", x_label='Frequency (GHz)', y_label='Amplitude (Arb. Units)')
         plot2.add_data_trace("Amplitude", {'color': 'C2'})
 
-        # plot3 = ManualPlotter("First refined sweep", x_label='Frequency (GHz)', y_label='Group Delay')
-        # plot3.add_data_trace("Group Delay", {'color': 'C3'})
-        # plot3.add_fit_trace("Group Delay Fit", {'color': 'C4'})
         self.plot1 = plot1
         self.plot1B = plot1B
         self.plot2 = plot2
-        # self.plot3 = plot3
-        return [plot1, plot1B, plot2] #, plot3]
+
+        return [plot1, plot1B, plot2] 
 
 class QubitTuneup(QubitCalibration):
     def __init__(self, qubit, f_start=5e9, f_stop=6e9, coarse_step=0.1e9, fine_step=1.0e6, averages=500, amp=1.0, **kwargs):

--- a/src/auspex/stream.py
+++ b/src/auspex/stream.py
@@ -152,17 +152,19 @@ class SweepAxis(DataAxis):
         """ Update value after each run.
         """
         if self.step < self.num_points():
-            if self.callback_func:
-                self.callback_func(self, self.experiment)
             self.value = self.points[self.step]
             if self.metadata is not None:
                 self.metadata_value = self.metadata[self.step]
+            if self.callback_func:
+                self.callback_func(self.value, self.experiment)
             logger.debug("Sweep Axis '{}' at step {} takes value: {}.".format(self.name,
-                                                                               self.step,self.value))
+                                                                               self.step+1,self.value))
             self.push()
             self.step += 1
             self.done = False
-        elif self.step == self.num_points():
+        
+        if self.step == self.num_points():
+            logger.debug("Sweep Axis '{}' claims to be done.".format(self.name))
             self.step = 0
             self.done = True
 
@@ -263,7 +265,7 @@ class DataStreamDescriptor(object):
 
     def expected_num_points(self):
         if len(self.axes)>0:
-            return reduce(lambda x,y: x*y, [len(a.original_points) for a in self.axes])
+            return reduce(lambda x,y: x*y, [len(a.points) for a in self.axes])
         else:
             return 0
 

--- a/src/auspex/sweep.py
+++ b/src/auspex/sweep.py
@@ -65,18 +65,6 @@ class Sweeper(object):
                     values.append((a.value,))
         return values, names
 
-    def is_adaptive(self):
-        return True in [a.refine_func is not None for a in self.axes]
-
-    def check_for_refinement(self, output_connectors_dict):
-        refined_axes = []
-        for a in self.axes:
-            if a.check_for_refinement(output_connectors_dict):
-                refined_axes.append(a.name)
-                break
-        if len(refined_axes) > 1:
-            raise Exception("More than one axis trying to refine simultaneously. This cannot be tolerated.")
-
     def done(self):
         return np.all([a.done for a in self.axes])
 

--- a/test/plotting_test_arbitrary.py
+++ b/test/plotting_test_arbitrary.py
@@ -20,8 +20,7 @@ from auspex.stream import OutputConnector, DataStreamDescriptor
 from auspex.filters.plot import Plotter, ManualPlotter
 from auspex.filters.io import DataBuffer
 from auspex.log import logger, logging
-# import auspex.analysis.switching as sw
-# from adapt import refine
+
 
 class TestExperiment(Experiment):
     """Here the run loop merely spews data until it fills up the stream. """

--- a/test/plotting_test_mesh.py
+++ b/test/plotting_test_mesh.py
@@ -14,7 +14,6 @@ import sys
 import itertools
 
 import numpy as np
-# import h5py
 import matplotlib.pyplot as plt
 
 from auspex.experiment import Experiment, FloatParameter
@@ -23,8 +22,6 @@ from auspex.filters.plot import Plotter, MeshPlotter
 from auspex.filters.io import WriteToHDF5
 from auspex.log import logger, logging
 from auspex.refine import delaunay_refine_from_file
-# import auspex.analysis.switching as sw
-# from adapt import refine
 
 class TestExperiment(Experiment):
     """Here the run loop merely spews data until it fills up the stream. """
@@ -66,5 +63,5 @@ if __name__ == '__main__':
 
     refine_func = delaunay_refine_from_file(wr, 'duration', 'amplitude', 'voltage', max_points=1000, plotter=fig1)
 
-    exp.add_sweep([exp.duration, exp.amplitude], points, refine_func=refine_func)
+    exp.add_sweep([exp.duration, exp.amplitude], points)
     exp.run_sweeps()

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -24,12 +24,6 @@ from QGL import *
 from auspex.qubit import *
 import bbndb
 
-def clear_test_data():
-    for file in glob.glob("test_*.h5"):
-        os.remove(file)
-    for direc in glob.glob("test_writehdf5*"):
-        shutil.rmtree(direc)
-
 class PipelineTestCase(unittest.TestCase):
 
     qubits = ["q1"]

--- a/test/test_sweeps.py
+++ b/test/test_sweeps.py
@@ -96,25 +96,6 @@ class SweepTestCase(unittest.TestCase):
         exp.add_sweep(exp.freq, np.linspace(0,10.0,3))
         exp.run_sweeps()
 
-    def test_run_adaptive_sweep(self):
-        exp = SweptTestExperiment()
-        pri = Print(name="Printer")
-
-        edges = [(exp.voltage, pri.sink)]
-        exp.set_graph(edges)
-
-        def rf(sweep_axis, exp):
-            logger.info("Running refinement function.")
-            if sweep_axis.num_points() >= 5:
-                return False
-            sweep_axis.add_points(sweep_axis.points[-1]*2)
-            return True
-
-        exp.add_sweep(exp.field, np.linspace(0,100.0,11))
-        exp.add_sweep(exp.freq, [1.0, 2.0], refine_func=rf)
-        exp.run_sweeps()
-        # self.assertTrue(pri.sink.output_streams[0].points_taken.value == 5*11*5)
-
     def test_unstructured_sweep(self):
         exp = SweptTestExperiment()
         pri = Print()

--- a/test/test_sweeps.py
+++ b/test/test_sweeps.py
@@ -137,11 +137,11 @@ class SweepTestCase(unittest.TestCase):
         self.assertTrue(pri.sink.input_streams[0].points_taken.value == exp.voltage.num_points())
 
     def test_unstructured_sweep_io(self):
-        exp = SweptTestExperiment()
-        pri = Print()
-        buf = DataBuffer()
 
         with tempfile.TemporaryDirectory() as tmpdirname:
+            exp = SweptTestExperiment()
+            pri = Print()
+            buf = DataBuffer()
             wri = WriteToFile(tmpdirname+"/test.auspex")
 
             edges = [(exp.voltage, pri.sink), (exp.voltage, buf.sink), (exp.voltage, wri.sink)]

--- a/test/test_sweeps.py
+++ b/test/test_sweeps.py
@@ -22,6 +22,21 @@ from auspex.filters.debug import Print
 from auspex.filters.io import WriteToFile, DataBuffer
 from auspex.log import logger
 
+
+pl = None
+cl = None
+
+# Set temporary output directories
+awg_dir = tempfile.TemporaryDirectory()
+kern_dir = tempfile.TemporaryDirectory()
+import QGL
+config.AWGDir = QGL.config.AWGDir = awg_dir.name
+config.KernelDir = kern_dir.name
+
+from QGL import *
+from auspex.qubit import *
+import bbndb
+
 class SweptTestExperiment(Experiment):
     """Here the run loop merely spews data until it fills up the stream. """
 
@@ -57,9 +72,16 @@ class SweptTestExperiment(Experiment):
         self.time_val += time_step
         self.voltage.push(data_row)
         logger.debug("Stream pushed points {}.".format(data_row))
-        logger.debug("Stream has filled {} of {} points".format(self.voltage.points_taken, self.voltage.num_points() ))
+        logger.debug("Stream has filled {} of {} points".format(self.voltage.points_taken.value, self.voltage.num_points() ))
 
 class SweepTestCase(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        global cl, pl
+
+        cl = ChannelLibrary(":memory:")
+        pl = PipelineManager()
 
     def test_add_sweep(self):
         exp = SweptTestExperiment()
@@ -148,6 +170,45 @@ class SweepTestCase(unittest.TestCase):
 
             data, desc = buf.get_data()
             self.assertTrue(np.allclose(desc.axes[0].points, coords))
+
+    def test_qubit_metafile_sweep(self):
+        cl.clear()
+        q1    = cl.new_qubit("q1")
+        aps1  = cl.new_APS2("BBNAPS1", address="192.168.5.102")
+        aps2  = cl.new_APS2("BBNAPS2", address="192.168.5.103")
+        x6_1  = cl.new_X6("X6_1", address="1", record_length=512)
+        holz1 = cl.new_source("Holz_1", "HolzworthHS9000", "HS9004A-009-1", power=-30)
+        holz2 = cl.new_source("Holz_2", "HolzworthHS9000", "HS9004A-009-2", power=-30)
+        cl.set_control(q1, aps1, generator=holz1)
+        cl.set_measure(q1, aps2, x6_1[1], generator=holz2)
+        cl.set_master(aps1, aps1.ch("m2"))
+        cl.commit()
+        pl.create_default_pipeline()
+        pl.reset_pipelines()
+        pl["q1"].clear_pipeline()
+        pl["q1"].stream_type = "integrated"
+        pl["q1"].create_default_pipeline(buffers=True)
+
+        def mf(sigma):
+            q1.pulse_params["sigma"] = sigma
+            mf = RabiAmp(q1, np.linspace(-1,1,21))
+            return mf
+
+        exp = QubitExperiment(mf(5e-9), averages=5)
+        exp.set_fake_data(x6_1, np.linspace(-1, 1, 21), random_mag=0.0)
+        exp.add_sweep("q1_sigma", np.linspace(1e-9, 10e-9, 10), metafile_func=mf)
+        exp.run_sweeps()
+
+        buf = list(exp.qubits_by_output.keys())[0]
+        ax  = buf.input_connectors["sink"].descriptor.axes[0]
+
+        self.assertTrue(buf.done.is_set())
+        
+        data, desc = buf.get_data()
+        self.assertTrue(np.allclose(np.linspace(1e-9, 10e-9, 10), desc.axes[0].points))
+        target_dat = np.vstack([np.linspace(-1.0, 1.0, 21)]*10)
+        self.assertTrue(np.allclose(target_dat, data.real))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This has ballooned into a larger PR:

1. Remove adaptive refinement from the sweeper internals — this can be done using external loops with much less agitation.
2. Add some general metadata to the AuspexDataContainer format, including a file format version, datestamp, and the possibility of adding arbitrary metadata to the writer. **This still needs to be wired up to the experiment class in some useful way.**
3. Improve the way parametric sweep information is stored in the metadata, and improve the API for performing parametric sweeps.
4. Allow general metafile sweeps for QGL recompilation. Example below:
```python
        def mf(sigma):
            q1.pulse_params["sigma"] = sigma
            mf = RabiAmp(q1, np.linspace(-1,1,21))
            return mf

        exp = QubitExperiment(mf(5e-9), averages=5)
        exp.set_fake_data(x6_1, np.linspace(-1, 1, 21), random_mag=0.0)
        exp.add_sweep("q1_sigma", np.linspace(1e-9, 10e-9, 10), metafile_func=mf)
        exp.run_sweeps()
```
Unlike before this "q1_sigma" sweep automatically creates a dummy parameter whose value gets passed to the specified `metafile_func`.