### PR TITLE
Fixed various aps3 issues. Added aps3 CW generator emulation mode

### DIFF
--- a/src/auspex/analysis/resonator_fits.py
+++ b/src/auspex/analysis/resonator_fits.py
@@ -176,7 +176,7 @@ def resonator_circle_fit(data, freqs, makePlots=False, manual_qc=None):
     # The phase of this is 2 pi f t
     # Hence, taking a linear regression against f and finding the slope can give you
     # an idea of t
-    phases = numpy.unwrap(numpy.angle(data))
+    phases = numpy.unwrap(numpy.angle(data)).real
     m,b,r,p,err = scipy.stats.linregress(freqs*1e-9,phases)
     bound = 2*numpy.absolute(m)/(2*numpy.pi)
     result = scipy.optimize.minimize_scalar(_circle_residuals, 0, method='Bounded', args=(data,freqs), bounds=(0, bound))

--- a/src/auspex/instruments/agilent.py
+++ b/src/auspex/instruments/agilent.py
@@ -924,7 +924,7 @@ class _AgilentNetworkAnalyzer(SCPIInstrument):
         while not meas_done:
             time.sleep(0.5)
             opc_bit = int(self.interface.ESR()) & 0x1
-            print(opc_bit)
+   #         print(opc_bit)
             if opc_bit == 1:
                 meas_done = True
 
@@ -977,7 +977,7 @@ class _AgilentNetworkAnalyzer(SCPIInstrument):
             interleaved_vals  = self.interface._resource.query_binary_values(':CALC:DATA? SDATA', datatype="f", is_big_endian=True, expect_termination=False)
 
         self.interface.write("SENS:SWE:MODE CONT")
-        vals = interleaved_vals[::2] + 1j*interleaved_vals[1::2]
+        vals = np.array(interleaved_vals[::2]) + 1j*np.array(interleaved_vals[1::2])
         #Get the associated frequencies
         freqs = np.linspace(self.frequency_start, self.frequency_stop, self.num_points)
         return (freqs, vals)

--- a/src/auspex/instruments/aps3.py
+++ b/src/auspex/instruments/aps3.py
@@ -720,8 +720,8 @@ class APS3(Instrument, metaclass=MakeBitFieldParams):
     sequencer_enable = BitFieldCommand(register=CSR_SEQ_CONTROL, shift=0,
         doc="""Sequencer, trigger input, modulator, SATA, VRAM, debug stream enable bit.""")
 
-    trigger_source = BitFieldCommand(register=CSR_SEQ_CONTROL, shift=1, mask=0b11, #mask added TB 2/15/22
-        value_map={"external": 0b00, "internal": 0b01, "software": 0b10, "message": 0b11, "system":0b10}) #Added system option to avoid an error TB 12/7/21
+    trigger_source = BitFieldCommand(register=CSR_SEQ_CONTROL, shift=1, mask=0b11, 
+        value_map={"external": 0b00, "internal": 0b01, "software": 0b10, "message": 0b11, "system":0b10}) 
 
     soft_trigger = BitFieldCommand(register=CSR_SEQ_CONTROL, shift=3)
     trigger_enable = BitFieldCommand(register=CSR_SEQ_CONTROL, shift=4)
@@ -861,7 +861,7 @@ class APS3(Instrument, metaclass=MakeBitFieldParams):
     ###### UTILITIES ###########################################################
     def run(self):
         logger.debug("Configuring JESD...")
-        APS3CommunicationManager.board(self.address).serial_configure_JESD(self.dac) #was commented  as of 9/23/21, uncommenting TB
+        APS3CommunicationManager.board(self.address).serial_configure_JESD(self.dac)
         sleep(0.01)
         logger.debug("Taking cache controller out of reset...")
         self.cache_controller = True

--- a/src/auspex/instruments/aps3.py
+++ b/src/auspex/instruments/aps3.py
@@ -6,7 +6,7 @@
 #
 #    http://www.apache.org/licenses/LICENSE-2.0
 
-__all__ = ['APS3']
+__all__ = ['APS3','APS3_generator']
 
 from .instrument import Instrument, is_valid_ipv4, Command, MetaInstrument
 from .bbn import MakeSettersGetters
@@ -19,6 +19,8 @@ from unittest.mock import Mock
 import collections
 from struct import pack, iter_unpack
 import serial
+from QGL.drivers.APS3Pattern import Sync,Wait,Waveform,Goto,ModulationCommand
+from QGL.PulseShapes import constant
 
 U32 = 0xFFFFFFFF #mask for 32-bit unsigned int
 U16 = 0xFFFF
@@ -338,7 +340,7 @@ class AMC599(object):
 
         # From AD9164 datasheet:
         # IOUTFS = 32 mA × (ANA_FULL_SCALE_CURRENT[9:0]/1023) + 8 mA
-        reg_value = int(1023 * (current - 8) / 32)
+        reg_value = int(1023 * (current - 8) / 32)  
 
         if self.ser is None:
             logger.debug('{:#x}'.format(reg_value & 0x3))
@@ -362,7 +364,7 @@ class AMC599(object):
 
         LSbits = self.serial_read_dac_register(dac, 0x041) & 0x03
         MSbits = self.serial_read_dac_register(dac, 0x042) & 0xFF
-        reg_value = (MSbits << 2) & LSbits
+        reg_value = (MSbits << 2) | LSbits
         return 32 * (reg_value / 1023) + 8
 
     def serial_set_nco_enable(self, dac, en):
@@ -636,6 +638,9 @@ class APS3(Instrument, metaclass=MakeBitFieldParams):
 
     def __init__(self, resource_name=None, name="Unlabeled APS3", debug=False):
         self.name = name
+        if len(resource_name) <3:
+            print("error: not enough parameters in resource name")
+            print(resource_name)
         self.resource_name = resource_name
         super().__init__()
 
@@ -669,6 +674,13 @@ class APS3(Instrument, metaclass=MakeBitFieldParams):
         self.dac = channel
 
         APS3CommunicationManager.connect(self.address)
+        #ipreg = self.read_register(CSR_IPV4)
+        ipreg = APS3CommunicationManager.board(self.address).read_memory(CSR_AXI_ADDR_BASE0 + CSR_IPV4, 1)
+        hexstring = '{:02X}{:02X}{:02X}{:02X}'.format(*map(int, self.address[0].split('.')))
+        if ipreg != int(hexstring, 16):
+            print("IP does not match expected value for ip", self.address[0], 'serial:', self.address[1])
+            print(ipreg, hexstring, int(hexstring,16))
+
 
         # Write the memory locations immediately
         self.write_register(CSR_WFA_OFFSET, (DRAM_WFA_0_LOC if self.dac == 0 else DRAM_WFA_1_LOC))
@@ -679,12 +691,22 @@ class APS3(Instrument, metaclass=MakeBitFieldParams):
         if APS3CommunicationManager.connected(self.address):
             APS3CommunicationManager.disconnect(self.address)
 
-    def write_register(self, offset, data):
+    def write_register(self, offset, data,dac = None):
         logger.debug(f"Setting CSR: {hex(offset)} to: {hex(data)}")
-        APS3CommunicationManager.board(self.address).write_memory((CSR_AXI_ADDR_BASE0 if self.dac == 0 else CSR_AXI_ADDR_BASE1) + offset, data)
+        # if self.csr0_master and ((offset is CSR_CACHE_CONTROL) or (offset is CSR_SEQ_CONTROL)) :
+        #     if shift is 4 or shift is 5 or ((offset is CSR_CACHE_CONTROL) and (shift is 0)):
+        #         logger.debug("Special case for csr0_master, setting for both DACs")
+        #         APS3CommunicationManager.board(self.address).write_memory(CSR_AXI_ADDR_BASE0 + offset, data)
+        #         APS3CommunicationManager.board(self.address).write_memory(CSR_AXI_ADDR_BASE1 + offset, data)
+        #         return
+        if dac == None:
+            dac = self.dac
+        APS3CommunicationManager.board(self.address).write_memory((CSR_AXI_ADDR_BASE0 if dac == 0 else CSR_AXI_ADDR_BASE1) + offset, data)
 
-    def read_register(self, offset, num_words = 1):
-        return APS3CommunicationManager.board(self.address).read_memory((CSR_AXI_ADDR_BASE0 if self.dac == 0 else CSR_AXI_ADDR_BASE1) + offset, num_words)
+    def read_register(self, offset, num_words = 1, dac = None):
+        if dac == None:
+            dac = self.dac
+        return APS3CommunicationManager.board(self.address).read_memory((CSR_AXI_ADDR_BASE0 if dac == 0 else CSR_AXI_ADDR_BASE1) + offset, num_words)
 
     def write_dram(self, offset, data):
         APS3CommunicationManager.board(self.address).write_memory(DRAM_AXI_BASE + offset, data)
@@ -707,8 +729,8 @@ class APS3(Instrument, metaclass=MakeBitFieldParams):
     sequencer_enable = BitFieldCommand(register=CSR_SEQ_CONTROL, shift=0,
         doc="""Sequencer, trigger input, modulator, SATA, VRAM, debug stream enable bit.""")
 
-    trigger_source = BitFieldCommand(register=CSR_SEQ_CONTROL, shift=1,
-        value_map={"external": 0b00, "internal": 0b01, "software": 0b10, "message": 0b11})
+    trigger_source = BitFieldCommand(register=CSR_SEQ_CONTROL, shift=1, mask=0b11, #mask added TB 2/15/22
+        value_map={"external": 0b00, "internal": 0b01, "software": 0b10, "message": 0b11, "system":0b10}) #Added system option to avoid an error TB 12/7/21
 
     soft_trigger = BitFieldCommand(register=CSR_SEQ_CONTROL, shift=3)
     trigger_enable = BitFieldCommand(register=CSR_SEQ_CONTROL, shift=4)
@@ -772,8 +794,8 @@ class APS3(Instrument, metaclass=MakeBitFieldParams):
         return np.array([[r00, r01], [r10, r11]], dtype=np.uint16)
 
     def set_correction_matrix(self, matrix):
-        row0 = ((matix[0, 0] & U16) << 16) | (matrix[0, 1] & U16)
-        row1 = ((matix[1, 0] & U16) << 16) | (matrix[1, 1] & U16)
+        row0 = ((matrix[0, 0] & U16) << 16) | (matrix[0, 1] & U16)
+        row1 = ((matrix[1, 0] & U16) << 16) | (matrix[1, 1] & U16)
         self.write_register(CSR_CMAT_R0, row0)
         self.write_register(CSR_CMAT_R1, row1)
 
@@ -811,7 +833,7 @@ class APS3(Instrument, metaclass=MakeBitFieldParams):
         self.write_register(CSR_BD_CONTROL, reg)
 
     trigger_input_select = BitFieldCommand(register=CSR_BD_CONTROL, shift=7,
-        doc="""True: Use the trigger form the other DAC as the trigger source.  When this bit is set then
+        doc="""True: Use the trigger from the other DAC as the trigger source.  When this bit is set then
                 for CSR0: DAC0 use DAC1 trigger; For CSR1 for DAC1 use DAC0 trigger.
                False: Use the trigger from the same DAC as the source.
                 for CSR0: DAC0 use DAC0 trigger; For CSR1 for DAC1 use DAC1 trigger.""")
@@ -848,7 +870,7 @@ class APS3(Instrument, metaclass=MakeBitFieldParams):
     ###### UTILITIES ###########################################################
     def run(self):
         logger.debug("Configuring JESD...")
-        #APS3CommunicationManager.board(self.address).serial_configure_JESD()
+        APS3CommunicationManager.board(self.address).serial_configure_JESD(self.dac) #was commented  as of 9/23/21, uncommenting TB
         sleep(0.01)
         logger.debug("Taking cache controller out of reset...")
         self.cache_controller = True
@@ -866,7 +888,7 @@ class APS3(Instrument, metaclass=MakeBitFieldParams):
         sleep(0.01)
         logger.debug("Resetting sequencer...")
         self.sequencer_enable = False
-
+        sleep(0.01)
     ###### SEQUENCE LOADING ####################################################
 
     sequence_filename = ''
@@ -1002,3 +1024,117 @@ class APS3(Instrument, metaclass=MakeBitFieldParams):
     @dac_shuffle_mode.setter
     def dac_shuffle_mode(self, value):
         APS3CommunicationManager.board(self.address).serial_set_shuffle_mode(self.dac, value)
+
+
+    def get_dac_temp(self, device_index=None):
+        if device_index is None:
+            device_index=self.dac
+        APS3CommunicationManager.board(self.address).serial_write_dac_register(device_index, 0x134, 0b1)
+        sleep(0.1)
+        return APS3CommunicationManager.board(self.address).serial_read_dac_register(device_index, 0x132) | (APS3CommunicationManager.board(self.address).serial_read_dac_register(device_index, 0x133)<<8)
+
+    def test_configure_JESD(self):
+        return APS3CommunicationManager.board(self.address).serial_configure_JESD(self.dac)
+
+class APS3_generator(APS3):
+
+    instrument_type = "Microwave Source"
+    reference = "FPGA"
+    sequence_length = 25e-6
+    cw_mode = True
+
+    def aps3_load_constant_waveform(self):
+        pulse = constant(amp=1, length=self.sequence_length, sampling_rate=5e9)
+        #wf_a, wf_b = pack_pulse_into_waveform(pulse)
+        WF_MAX_AMP = (1 << 15) - 1
+        self.load_waveforms([int(x * WF_MAX_AMP) for x in np.real(pulse)], 
+                            [int(x * WF_MAX_AMP) for x in np.imag(pulse)])
+        return len(pulse) // 2
+
+    def connect(self, resource_name=None):
+        super().connect(resource_name)
+        sleep(0.1)
+        self.dac_FIR85_enable = False
+        self.dac_switch_mode = 'MIX'
+        self.dac_full_scale_current = 40
+        self.bypass_nco = True
+        self.bypass_modulator = True
+        self.dac_nco_enable = True
+        self.dac_output_mux = 'APS'
+        self.trigger_input_select = 0b1
+        self.trigger_output_select = 0x2
+        self.dac_pll_reference = 'FPGA'
+        self.csr0_master = True
+        self.marker_delay = 0
+        self.delay = 0
+        self.trigger_source = 'external'
+
+        if self.cw_mode is False:
+            tmplen = self.aps3_load_constant_waveform()
+            wf_seq_cw = [Sync(),
+                         Wait(),
+                         Waveform(0x0, tmplen, False, write=True),
+                         Waveform(0x0, tmplen, False, write=True),
+                         Goto(0x0)]
+            self.trigger_source = 'external'
+            self.trigger_input_select = 0b1
+        else:
+            print("Hello!")
+            tmplen = self.aps3_load_constant_waveform()
+            wf_seq_cw = [Sync(),
+                         Waveform(0x0, tmplen, False, write=True),
+                         Goto(0x1)]
+            self.trigger_source='internal'
+            self.trigger_input_select = 0b0
+
+        self.load_sequence([s.flatten() for s in wf_seq_cw])
+    
+    def load_sequence(self, arg):
+        print("Loading sequence to APS3 generator")
+        super().load_sequence(arg)
+
+    @property
+    def output(self):
+        return self.sequencer_enable
+    @output.setter
+    def output(self, value):
+        if value == True:
+            self.run()
+            return True
+        elif value == False:
+            self.stop()
+            return False
+        else:
+            return False
+
+    @property
+    def frequency(self):
+        return self.dac_nco_frequency
+    @frequency.setter
+    def frequency(self, value):
+        self.dac_nco_frequency = value
+
+    #Power setter disabled for now
+    @property
+    def power(self):
+        return 0
+    @power.setter
+    def power(self, value):
+        return 0
+
+    @property
+    def reference(self):
+        return self.dac_pll_reference
+    @reference.setter
+    def reference(self, value):
+        ref_opts = ["FPGA", "REF IN"]
+        if value in ref_opts:
+            self.dac_pll_reference = value
+        else:
+            raise ValueError("Reference must be one of {}.".format(ref_opts))
+
+    def write_register(self, offset, data):
+        super().write_register(offset,data)
+
+    def read_register(self, offset, num_words = 1):
+        return super().read_register(offset,num_words)

--- a/src/auspex/instruments/aps3.py
+++ b/src/auspex/instruments/aps3.py
@@ -677,8 +677,8 @@ class APS3(Instrument, metaclass=MakeBitFieldParams):
         ipreg = self.read_register(CSR_IPV4,dac=0)
         hexstring = '{:02X}{:02X}{:02X}{:02X}'.format(*map(int, self.address[0].split('.')))
         if ipreg != int(hexstring, 16):
-            print("IP does not match expected value for ip", self.address[0], 'serial:', self.address[1])
-            print(ipreg, hexstring, int(hexstring,16))
+            logger.warning("IP does not match expected value for ip", self.address[0], 'serial:', self.address[1])
+            logger.warning(ipreg, hexstring, int(hexstring,16))
         # Write the memory locations immediately
         self.write_register(CSR_WFA_OFFSET, (DRAM_WFA_0_LOC if self.dac == 0 else DRAM_WFA_1_LOC))
         self.write_register(CSR_WFB_OFFSET, (DRAM_WFB_0_LOC if self.dac == 0 else DRAM_WFB_1_LOC))

--- a/src/auspex/instruments/aps3.py
+++ b/src/auspex/instruments/aps3.py
@@ -674,14 +674,11 @@ class APS3(Instrument, metaclass=MakeBitFieldParams):
         self.dac = channel
 
         APS3CommunicationManager.connect(self.address)
-        #ipreg = self.read_register(CSR_IPV4)
-        ipreg = APS3CommunicationManager.board(self.address).read_memory(CSR_AXI_ADDR_BASE0 + CSR_IPV4, 1)
+        ipreg = self.read_register(CSR_IPV4,dac=0)
         hexstring = '{:02X}{:02X}{:02X}{:02X}'.format(*map(int, self.address[0].split('.')))
         if ipreg != int(hexstring, 16):
             print("IP does not match expected value for ip", self.address[0], 'serial:', self.address[1])
             print(ipreg, hexstring, int(hexstring,16))
-
-
         # Write the memory locations immediately
         self.write_register(CSR_WFA_OFFSET, (DRAM_WFA_0_LOC if self.dac == 0 else DRAM_WFA_1_LOC))
         self.write_register(CSR_WFB_OFFSET, (DRAM_WFB_0_LOC if self.dac == 0 else DRAM_WFB_1_LOC))

--- a/src/auspex/instruments/aps3.py
+++ b/src/auspex/instruments/aps3.py
@@ -690,12 +690,6 @@ class APS3(Instrument, metaclass=MakeBitFieldParams):
 
     def write_register(self, offset, data,dac = None):
         logger.debug(f"Setting CSR: {hex(offset)} to: {hex(data)}")
-        # if self.csr0_master and ((offset is CSR_CACHE_CONTROL) or (offset is CSR_SEQ_CONTROL)) :
-        #     if shift is 4 or shift is 5 or ((offset is CSR_CACHE_CONTROL) and (shift is 0)):
-        #         logger.debug("Special case for csr0_master, setting for both DACs")
-        #         APS3CommunicationManager.board(self.address).write_memory(CSR_AXI_ADDR_BASE0 + offset, data)
-        #         APS3CommunicationManager.board(self.address).write_memory(CSR_AXI_ADDR_BASE1 + offset, data)
-        #         return
         if dac == None:
             dac = self.dac
         APS3CommunicationManager.board(self.address).write_memory((CSR_AXI_ADDR_BASE0 if dac == 0 else CSR_AXI_ADDR_BASE1) + offset, data)

--- a/src/auspex/qubit/mixer_calibration.py
+++ b/src/auspex/qubit/mixer_calibration.py
@@ -68,8 +68,8 @@ class MixerCalibration(Calibration):
     MAX_OFFSET = 0.4
     MIN_AMPLITUDE = 0.2
     MAX_AMPLITUDE = 1.5
-    MIN_PHASE = -0.3
-    MAX_PHASE = 0.3
+    MIN_PHASE = -0.7
+    MAX_PHASE = 0.7
 
     def __init__(self, channel, spectrum_analyzer, mixer="control", first_cal="phase",
                 offset_range = (-0.2,0.2), amp_range = (0.4,0.8), phase_range = (-np.pi/2,np.pi/2),
@@ -265,7 +265,7 @@ class MixerCalibrationExperiment(Experiment):
             self._LO = self._sa.LO_source
         else:
             self._LO = None #A spectrum analyzer with built-in LO
-
+        self._LO = self._sa.LO_source    
         if mixer.lower() == "measure":
             self._awg = channel.measure_chan.phys_chan.transmitter
             self._phys_chan = channel.measure_chan.phys_chan
@@ -288,8 +288,11 @@ class MixerCalibrationExperiment(Experiment):
             # For easy lookup
             instr.proxy_obj = instrument
             instrument._locked = False
+            if hasattr(instr, 'cw_mode'):
+                instr.cw_mode=True
             instrument.instr = instr
             instrument._locked = True
+
             # Add to the experiment's instrument list
             self._instruments[instrument.label] = instr
             self.instruments.append(instr)

--- a/src/auspex/qubit/pulse_calibration.py
+++ b/src/auspex/qubit/pulse_calibration.py
@@ -668,18 +668,28 @@ class RamseyCalibration(QubitCalibration):
         if self.first_ramsey:
             rcvr = self.qubit.measure_chan.receiver_chan.receiver
             self.source_proxy = self.qubit.phys_chan.generator # DB object
-            self.qubit_source = exp._instruments[self.source_proxy.label] # auspex instrument
-            self.orig_freq = self.source_proxy.frequency + self.qubit.frequency
+ #           self.qubit_source = exp._instruments[self.source_proxy.label] # auspex instrument
+ #           self.orig_freq = self.source_proxy.frequency + self.qubit.frequency
             if self.set_source:
+  #              self.source_proxy = self.qubit.phys_chan.generator # DB object
+                self.qubit_source = exp._instruments[self.source_proxy.label] # auspex instrument
+                self.orig_freq = self.source_proxy.frequency + self.qubit.frequency
                 self.source_proxy.frequency += self.added_detuning
             else:
                 #self.orig_freq = self.qubit.frequency
-                self.qubit.frequency = self.qubit.frequency +  round(self.orig_freq+self.added_detuning,10)
+                if self.source_proxy is not None:
+                    self.qubit_source = exp._instruments[self.source_proxy.label] # auspex instrument
+                    self.orig_freq = self.source_proxy.frequency + self.qubit.frequency
+                else:
+                    self.orig_freq = self.qubit.frequency 
+                self.qubit.frequency = self.orig_freq +  round(self.added_detuning,10)
 
     def _calibrate(self):
         self.first_ramsey = True
 
         data, _ = self.run_sweeps()
+        print("Sleep 10 between Ramsey experiments")
+        time.sleep(10)
         try:
             ramsey_fit = RamseyFit(self.delays, data, two_freqs=self.two_freqs, AIC=self.AIC)
             fit_freqs = ramsey_fit.fit_params["f"]
@@ -696,11 +706,15 @@ class RamseyCalibration(QubitCalibration):
         #TODO: set conditions for success
         fit_freq_A = np.mean(fit_freqs) #the fit result can be one or two frequencies
         fit_err_A = np.sum(fit_err)
+        print(fit_freq_A)
         if self.set_source:
             self.source_proxy.frequency = round(self.orig_freq - self.qubit.frequency + self.added_detuning + fit_freq_A/2, 10)
             #self.qubit_source.frequency = self.source_proxy.frequency
         else:
-            self.qubit.frequency = round(self.orig_freq - self.source_proxy.frequency + self.added_detuning + fit_freq_A/2, 10)
+            if self.source_proxy is not None:
+                self.qubit.frequency = round(self.orig_freq - self.source_proxy.frequency + self.added_detuning + fit_freq_A/2, 10)
+            else:    
+                self.qubit.frequency = round(self.orig_freq + self.added_detuning + fit_freq_A/2, 10)
 
         self.first_ramsey = False
 
@@ -823,6 +837,7 @@ class PhaseEstimation(QubitCalibration):
         elif done == 1:
             self.succeeded = True
         else:
+            print("Error:", done, self.succeeded)
             raise Exception()
 
     def init_plots(self):


### PR DESCRIPTION
Added APS3generator, where APS3 channel can be configured as a CW generator.

Fixed issue with APS3 dac channels not reconfiguring properly when one channel is in the sequence but the second channel is missing. The previous version was causing the module to fire both channels even when one channel is missing and still had a sequence saved from a previous experiment!

Fixed VNA error in acquired data format
