### PR TITLE
Fix/float command resolution

### DIFF
--- a/src/auspex/instruments/agilent.py
+++ b/src/auspex/instruments/agilent.py
@@ -735,9 +735,9 @@ class _AgilentNetworkAnalyzer(SCPIInstrument):
 
     ##Basic SCPI commands.
     frequency_center    = FloatCommand(scpi_string=":SENSe:FREQuency:CENTer")
-    frequency_start     = FloatCommand(scpi_string=":SENSe:FREQuency:STARt")
-    frequency_stop      = FloatCommand(scpi_string=":SENSe:FREQuency:STOP")
-    frequency_span      = FloatCommand(scpi_string=":SENSe:FREQuency:SPAN")
+    frequency_start     = FloatCommand(scpi_string=":SENSe:FREQuency:STARt", formatter="{:.0f}")
+    frequency_stop      = FloatCommand(scpi_string=":SENSe:FREQuency:STOP", formatter="{:.0f}")
+    frequency_span      = FloatCommand(scpi_string=":SENSe:FREQuency:SPAN", formatter="{:.0f}")
     if_bandwidth        = FloatCommand(scpi_string=":SENSe1:BANDwidth")
     num_points          = IntCommand(scpi_string=":SENSe:SWEep:POINTS")
 
@@ -788,9 +788,10 @@ class _AgilentNetworkAnalyzer(SCPIInstrument):
             the port being in `OFF` mode, while `True` corresponds to the port being in `AUTO` mode.
         """
         if isinstance(outp, dict):
-            for k, v in self.outp.items():
+            for k, v in outp.items():
                 val = "AUTO" if v else "OFF"
-                self.interface.write(f"SOUR:POW{k}:MODE {val}")
+                self.interface.write(f" {val}")
+                print(f"Setting port {k} to {val}")
         else:
             val = "AUTO" if outp else "OFF"
             for p in self.ports:

--- a/src/auspex/instruments/agilent.py
+++ b/src/auspex/instruments/agilent.py
@@ -735,9 +735,9 @@ class _AgilentNetworkAnalyzer(SCPIInstrument):
 
     ##Basic SCPI commands.
     frequency_center    = FloatCommand(scpi_string=":SENSe:FREQuency:CENTer")
-    frequency_start     = FloatCommand(scpi_string=":SENSe:FREQuency:STARt", formatter="{:.0f}")
-    frequency_stop      = FloatCommand(scpi_string=":SENSe:FREQuency:STOP", formatter="{:.0f}")
-    frequency_span      = FloatCommand(scpi_string=":SENSe:FREQuency:SPAN", formatter="{:.0f}")
+    frequency_start     = FloatCommand(scpi_string=":SENSe:FREQuency:STARt", formatter={:.0f})
+    frequency_stop      = FloatCommand(scpi_string=":SENSe:FREQuency:STOP", formatter={:.0f})
+    frequency_span      = FloatCommand(scpi_string=":SENSe:FREQuency:SPAN", formatter={:.0f})
     if_bandwidth        = FloatCommand(scpi_string=":SENSe1:BANDwidth")
     num_points          = IntCommand(scpi_string=":SENSe:SWEep:POINTS")
 
@@ -788,10 +788,9 @@ class _AgilentNetworkAnalyzer(SCPIInstrument):
             the port being in `OFF` mode, while `True` corresponds to the port being in `AUTO` mode.
         """
         if isinstance(outp, dict):
-            for k, v in outp.items():
+            for k, v in self.outp.items():
                 val = "AUTO" if v else "OFF"
-                self.interface.write(f" {val}")
-                print(f"Setting port {k} to {val}")
+                self.interface.write(f"SOUR:POW{k}:MODE {val}")
         else:
             val = "AUTO" if outp else "OFF"
             for p in self.ports:

--- a/src/auspex/instruments/instrument.py
+++ b/src/auspex/instruments/instrument.py
@@ -41,6 +41,9 @@ class Command(object):
                 setattr(self, a, self.kwargs.pop(a))
             else:
                 setattr(self, a, None) # Default to None
+        # Permit overiding the 'formatter' but keep the one defined as class variable if none is given
+        if 'formatter' in self.kwargs:
+            self.formatter = self.kwargs.pop('formatter')
 
         if 'doc' in self.kwargs:
             self.doc = self.kwargs.pop('doc')


### PR DESCRIPTION
Each Command subclass for a SCPI instrument defines a "formatter" which translates an assigned value to a string that can get sent to the instrument hardware. In some cases, the default formatter is inadequate, and this fix lets the Command be instantiated with a formatter that overrides the generic one defined as a class variable for the Command class.

Example: FloatCommand defaults to the "{:E}" formatter, which produces a string with six digits of precision. This isn't sufficient to set frequency start, stop, and span for a VNA with better than 1 kHz resolution.

This fix updates the Agilent NetowrkAnalyzer to permit 1-Hz frequency resolution.